### PR TITLE
Improve drf-sideloading api

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,15 +46,12 @@ Import Mixin `SideloadableRelationsMixin`:
 
     from drf_sideloading.mixins import SideloadableRelationsMixin
 
-::
 
-    Include mixin in view, define serializers dict `sideloadable_relations` and `base_model_name`
+Include mixin in view, define serializers dict `sideloadable_relations` and `base_model_name`
 
-::
-
-    Defining primary relationship is optional if defined defaults will be overrided
-    In below case we define primary relationship along with side ones.
-    By adding `'product': {'primary':True},` in `sideloadable_relations` dict we
+Defining primary relationship is optional if defined defaults will be overrided
+In below case we define primary relationship along with side ones.
+By adding `'product': {'primary':True},` in `sideloadable_relations` dict we
 
 .. code-block:: python
 
@@ -72,13 +69,56 @@ Import Mixin `SideloadableRelationsMixin`:
             'partner': PartnerSerializer
         }
 
-.. line-block::
-
-    Add extra parameter and define comma separated relations:
-
-    `GET` `http://example.com/product/?sideload=category,partner,supplier`
 
 
+Add extra parameter and define comma separated relations:
+
+``GET /product/?sideload=category,partner,supplier``
+
+
+.. sourcecode:: json
+
+    {
+        "partner": [
+            {
+                "id": 1,
+                ...
+            },
+            {
+                "id": 2,
+                ...
+            },
+            {
+                "id": 3,
+                ...
+            }
+        ],
+        "categories": [
+            {
+                "id": 1,
+                ...
+            }
+        ],
+        "suppliers": [
+            {
+                "id": 1,
+                ...
+            }
+        ],
+        "products": [
+            {
+                "id": 1,
+                "name": "Product 1",
+                "category": 1,
+                "supplier": 1,
+                "partner": [
+                    1,
+                    2,
+                    3
+                ]
+            }
+        ]
+    }
 
 
 .. code-block:: python

--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,10 @@ Import Mixin `SideloadableRelationsMixin`:
 
 Include mixin in view, define serializers dict `sideloadable_relations` and `base_model_name`
 
+Defining primary relationship is optional if defined defaults will be overrided
+In below case we define primary relationship along with side ones.
+By adding `'product': {'primary':True},` in `sideloadable_relations` dict we
+
 .. code-block:: python
 
     class ProductViewSet(SideloadableRelationsMixin, viewsets.ModelViewSet):
@@ -50,22 +54,46 @@ Include mixin in view, define serializers dict `sideloadable_relations` and `bas
         serializer_class = ProductSerializer
 
         sideloadable_relations = {
-            'product': {'primary':True, 'serializer': ProductSerializer},
+            'product': {'primary':True},
             'category': CategorySerializer,
             'supplier': SupplierSerializer,
             'partner': PartnerSerializer
         }
 
+.. line-block::
 
-Add extra parameter and define comma separated relations:
+    Add extra parameter and define comma separated relations:
 
-`GET` `http://example.com/product/?sideload=category,partner,supplier`
+    `GET` `http://example.com/product/?sideload=category,partner,supplier`
+
+
+
+
+.. code-block:: python
+
+    sideloadable_relations = {
+        'product': {'primary': True, 'serializer': ProductSerializer},
+        'category': CategorySerializer,
+        'supplier': SupplierSerializer,
+        'partner': PartnerSerializer
+    }
+
+
 
 
 Features
 --------
 
-* TODO
+`sideloadable_relations` dict values supports following types
+    *  `serializers.Serializer` or subclass
+    * `dictionary` with following keys
+        * `primary` - to indicate primary model
+        * `serializer` - serializer class
+        * `name` - to override name of the sideloaded relation
+
+
+TODO
+
 * fix documentation
 * improve coverage
 * python3 support

--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,14 @@ drf-sideloading
     :target: http://drf-sideloading.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
+.. image:: https://img.shields.io/pypi/dm/drf-sideloading.svg?maxAge=3600
+    :alt: PyPI Downloads
+    :target: https://pypi.python.org/pypi/drf-sideloading
+
+.. image:: https://img.shields.io/github/license/mashape/apistatus.svg?maxAge=2592000
+    :alt: License is MIT
+    :target: https://github.com/namespace-ee/drf-sideloading/blob/master/LICENSE
+
 Extention for Django Rest Framework to enable simple sidloading
 
 Documentation
@@ -38,11 +46,15 @@ Import Mixin `SideloadableRelationsMixin`:
 
     from drf_sideloading.mixins import SideloadableRelationsMixin
 
-Include mixin in view, define serializers dict `sideloadable_relations` and `base_model_name`
+::
 
-Defining primary relationship is optional if defined defaults will be overrided
-In below case we define primary relationship along with side ones.
-By adding `'product': {'primary':True},` in `sideloadable_relations` dict we
+    Include mixin in view, define serializers dict `sideloadable_relations` and `base_model_name`
+
+::
+
+    Defining primary relationship is optional if defined defaults will be overrided
+    In below case we define primary relationship along with side ones.
+    By adding `'product': {'primary':True},` in `sideloadable_relations` dict we
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -84,8 +84,8 @@ Import Mixin `SideloadableRelationsMixin`:
 .. code-block:: python
 
     sideloadable_relations = {
-        'product': {'primary': True, 'serializer': ProductSerializer},
-        'category': CategorySerializer,
+        'product': {'primary': True, 'serializer': ProductSerializer, 'name': 'products'},
+        'category': {'serializer': CategorySerializer, 'name': 'categories'},
         'supplier': SupplierSerializer,
         'partner': PartnerSerializer
     }

--- a/README.rst
+++ b/README.rst
@@ -121,6 +121,8 @@ Add extra parameter and define comma separated relations:
     }
 
 
+Another use case
+
 .. code-block:: python
 
     sideloadable_relations = {

--- a/README.rst
+++ b/README.rst
@@ -49,10 +49,8 @@ Include mixin in view, define serializers dict `sideloadable_relations` and `bas
         queryset = Product.objects.all()
         serializer_class = ProductSerializer
 
-        base_model_name = 'product'
-
         sideloadable_relations = {
-            'product': ProductSerializer,
+            'product': {'primary':True, 'serializer': ProductSerializer},
             'category': CategorySerializer,
             'supplier': SupplierSerializer,
             'partner': PartnerSerializer

--- a/docs/drf_sideloading.rst
+++ b/docs/drf_sideloading.rst
@@ -1,0 +1,30 @@
+drf\_sideloading package
+========================
+
+Submodules
+----------
+
+drf\_sideloading\.mixins module
+-------------------------------
+
+.. automodule:: drf_sideloading.mixins
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+drf\_sideloading\.serializers module
+------------------------------------
+
+.. automodule:: drf_sideloading.serializers
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: drf_sideloading
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,0 +1,7 @@
+drf_sideloading
+===============
+
+.. toctree::
+   :maxdepth: 4
+
+   drf_sideloading

--- a/drf_sideloading/mixins.py
+++ b/drf_sideloading/mixins.py
@@ -22,7 +22,9 @@ class SideloadableRelationsMixin(object):
         for relation_name, properties in self.sideloadable_relations.iteritems():
             if isinstance(properties, dict):
                 for name, value in properties.iteritems():
-                    if name == 'primary':
+                    if name == 'primary' and value:
+                        if not properties.get('serializer'):
+                            self.sideloadable_relations[relation_name]['serializer'] = self.primary_serializer_class
                         return relation_name
         self.sideloadable_relations[self.default_primary_object_name] = self.primary_serializer_class
         return self.default_primary_object_name

--- a/drf_sideloading/mixins.py
+++ b/drf_sideloading/mixins.py
@@ -10,6 +10,32 @@ class SideloadableRelationsMixin(object):
     base_model_name = ''
     relations_set = {}
 
+
+    {
+        'relation_name': 'display_name'
+    }
+
+    def __init__(self, **kwargs):
+        self.primary_serializer_class = self.get_serializer_class()
+
+    #     Todo sideload relations analyze
+
+        if not self.sideloadable_relations:
+            raise Exception
+        # find primary model and serializer
+        # get_primary_relation
+        #
+        self.sideloadable_relations
+
+
+
+
+    def init(self, sideload):
+        if not sideload:
+            return False
+
+        self.parse_query_param(sideload)
+
     def list(self, request, *args, **kwargs):
         sideload = request.query_params.get(self.get_param_name(), None)
         if not sideload:

--- a/drf_sideloading/mixins.py
+++ b/drf_sideloading/mixins.py
@@ -5,36 +5,27 @@ from .serializers import SideLoadableSerializer
 
 class SideloadableRelationsMixin(object):
     query_param_name = 'sideload'
+    default_primary_object_name = 'self'
 
     relation_names = []
     base_model_name = ''
     relations_set = {}
 
-
-    {
-        'relation_name': 'display_name'
-    }
-
     def __init__(self, **kwargs):
         self.primary_serializer_class = self.get_serializer_class()
 
-    #     Todo sideload relations analyze
-
         if not self.sideloadable_relations:
             raise Exception
-        # find primary model and serializer
-        # get_primary_relation
-        #
-        self.sideloadable_relations
+        self.primary_object_name = self.get_primary_relation_name()
 
-
-
-
-    def init(self, sideload):
-        if not sideload:
-            return False
-
-        self.parse_query_param(sideload)
+    def get_primary_relation_name(self):
+        for relation_name, properties in self.sideloadable_relations.iteritems():
+            if isinstance(properties, dict):
+                for name, value in properties.iteritems():
+                    if name == 'primary':
+                        return relation_name
+        self.sideloadable_relations[self.default_primary_object_name] = self.primary_serializer_class
+        return self.default_primary_object_name
 
     def list(self, request, *args, **kwargs):
         sideload = request.query_params.get(self.get_param_name(), None)
@@ -67,21 +58,30 @@ class SideloadableRelationsMixin(object):
         return self.query_param_name
 
     def parse_query_param(self, sideload_relations):
+        """ Parse query param and take validated names
+
+        :param sideload_relations string
+        :return valid relation names list
+
+        comma separated relation names may contain invalid or unusable characters.
+        This function finds string match between requested names and defined relation in view
+
+        """
         relation_names = sideload_relations.split(',')
-        # only take valid names
-        self.relation_names = (set(relation_names)
-                               & set(self.sideloadable_relations.keys())) - set([self.base_model_name])
+        self.relation_names = \
+            (set(relation_names) & set(self.sideloadable_relations.keys())) - set([self.primary_object_name])
         return relation_names
 
     def get_sideloadable_page(self, page):
-        sideloadable_page = {self.base_model_name: page}
+        sideloadable_page = {self.primary_object_name: page}
         for rel in self.relation_names:
             single_relation_set = set()
             for row in page:
-                if getattr(row, rel).__class__.__name__ == 'ManyRelatedManager':
-                    single_relation_set = single_relation_set | set(getattr(row, rel).all())
-                else:
-                    single_relation_set.add(getattr(row, rel))
+                if hasattr(row, rel):
+                    if getattr(row, rel).__class__.__name__ == 'ManyRelatedManager':
+                        single_relation_set = single_relation_set | set(getattr(row, rel).all())
+                    else:
+                        single_relation_set.add(getattr(row, rel))
             sideloadable_page[rel] = single_relation_set
         return sideloadable_page
 

--- a/drf_sideloading/mixins.py
+++ b/drf_sideloading/mixins.py
@@ -8,8 +8,6 @@ class SideloadableRelationsMixin(object):
     default_primary_object_name = 'self'
 
     relation_names = []
-    base_model_name = ''
-    relations_set = {}
 
     def __init__(self, **kwargs):
         self.primary_serializer_class = self.get_serializer_class()

--- a/drf_sideloading/serializers.py
+++ b/drf_sideloading/serializers.py
@@ -16,3 +16,11 @@ class SideLoadableSerializer(serializers.Serializer):
             else:
                 serializer_class = relation_property
             self.fields[relation_name] = serializer_class(many=True, read_only=True)
+
+    def to_representation(self, obj):
+        primitive_repr = super(SideLoadableSerializer, self).to_representation(obj)
+        for relation_name, properties in self.context['view'].sideloadable_relations.iteritems():
+            if isinstance(properties, dict) and primitive_repr.get(relation_name) and properties.get('name'):
+                primitive_repr[properties.get('name')] = primitive_repr[relation_name]
+                del primitive_repr[relation_name]
+        return primitive_repr

--- a/drf_sideloading/serializers.py
+++ b/drf_sideloading/serializers.py
@@ -10,5 +10,9 @@ class SideLoadableSerializer(serializers.Serializer):
         self.many = True
 
         for relation_name in args[0].keys():
-            self.fields[relation_name] = kwargs['context']['view'].sideloadable_relations[relation_name](many=True,
-                                                                                                         read_only=True)
+            relation_property = kwargs['context']['view'].sideloadable_relations[relation_name]
+            if isinstance(relation_property, dict):
+                serializer_class = relation_property['serializer']
+            else:
+                serializer_class = relation_property
+            self.fields[relation_name] = serializer_class(many=True, read_only=True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,15 +8,20 @@ test_drf-sideloading
 Tests for `drf-sideloading` models api.
 """
 
-from django.test import TestCase
-
 from django.core.urlresolvers import reverse
+from django.test import TestCase
 from rest_framework import status
 
 from tests.models import Category, Supplier, Product, Partner
+from tests.serializers import ProductSerializer, CategorySerializer, SupplierSerializer, PartnerSerializer
+from tests.viewsets import ProductViewSet
 
 
-class TestDrfSideloading(TestCase):
+class BaseTestCase(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(BaseTestCase, cls).setUpClass()
 
     def setUp(self):
         category = Category.objects.create(name='Category')
@@ -29,6 +34,11 @@ class TestDrfSideloading(TestCase):
         product.partner.add(partner2)
         product.save()
 
+
+class GeneralTestMixin(object):
+    """Collection of general tests without requesting sideloading enabled
+    To check that drf-sideloading mixin doesn't break anything"""
+
     def test_product_list(self):
         response = self.client.get(reverse('product-list'), format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -36,11 +46,15 @@ class TestDrfSideloading(TestCase):
         self.assertEqual(1, len(response.data))
         self.assertEqual('Product', response.data[0]['name'])
 
+
+class SideloadRelatedTestMixin(object):
+    """Reusable test which will be running by defining different configuration"""
+
     def test_sideloading_product_list(self):
         response = self.client.get(reverse('product-list'), {'sideload': 'category,supplier'})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        expected_loads = ['category', 'supplier', 'product']
+        expected_loads = ['category', 'supplier'] + [self.primary_model_name]
 
         self.assertEqual(3, len(response.data))
         self.assertEqual(set(expected_loads), set(response.data))
@@ -49,7 +63,7 @@ class TestDrfSideloading(TestCase):
         response = self.client.get(reverse('product-list'), {'sideload': 'category'})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        expected_loads = ['category', 'product']
+        expected_loads = ['category'] + [self.primary_model_name]
 
         self.assertEqual(2, len(response.data))
         self.assertEqual(set(expected_loads), set(response.data))
@@ -58,7 +72,7 @@ class TestDrfSideloading(TestCase):
         response = self.client.get(reverse('product-list'), {'sideload': 'supplier'})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        expected_loads = ['supplier', 'product']
+        expected_loads = ['supplier'] + [self.primary_model_name]
 
         self.assertEqual(2, len(response.data))
         self.assertEqual(set(expected_loads), set(response.data))
@@ -67,12 +81,43 @@ class TestDrfSideloading(TestCase):
         response = self.client.get(reverse('product-list'), {'sideload': 'partner'})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        expected_loads = ['product', 'partner']
+        expected_loads = ['partner'] + [self.primary_model_name]
 
         self.assertEqual(2, len(response.data))
         self.assertEqual(set(expected_loads), set(response.data))
 
         self.assertEqual(2, len(response.data['partner']))
+
+
+class TestDrfSideloadingSimpleAPi(BaseTestCase, SideloadRelatedTestMixin, GeneralTestMixin):
+    @classmethod
+    def setUpClass(cls):
+        super(TestDrfSideloadingSimpleAPi, cls).setUpClass()
+        # Define just serializer without indicate primary model
+        sideloadable_relations = {
+            'category': CategorySerializer,
+            'supplier': SupplierSerializer,
+            'partner': PartnerSerializer
+        }
+        ProductViewSet.sideloadable_relations = sideloadable_relations
+
+        # used for assertion
+        cls.primary_model_name = 'self'
+
+
+class TestDrfSideloading(BaseTestCase, SideloadRelatedTestMixin, GeneralTestMixin):
+    @classmethod
+    def setUpClass(cls):
+        super(TestDrfSideloading, cls).setUpClass()
+        sideloadable_relations = {
+            'product': {'primary': True, 'serializer': ProductSerializer},
+            'category': CategorySerializer,
+            'supplier': SupplierSerializer,
+            'partner': PartnerSerializer
+        }
+        ProductViewSet.sideloadable_relations = sideloadable_relations
+
+        cls.primary_model_name = 'product'
 
     # negative test cases
     def test_sideloading_supplier_empty(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -129,9 +129,9 @@ class TestDrfSideloadingPrimary(BaseTestCase, SideloadRelatedTestMixin, GeneralT
     """Define only primary True property for primary model"""
 
     @classmethod
-    @unittest.skip("testing skipping")
     def setUpClass(cls):
         super(TestDrfSideloadingPrimary, cls).setUpClass()
+        cls.save_sideloadable_relations = ProductViewSet.sideloadable_relations
         sideloadable_relations = {
             'product': {'primary': True},
             'category': CategorySerializer,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,6 +7,7 @@ test_drf-sideloading
 
 Tests for `drf-sideloading` models api.
 """
+import unittest
 
 from django.core.urlresolvers import reverse
 from django.test import TestCase
@@ -103,6 +104,43 @@ class TestDrfSideloadingSimpleAPi(BaseTestCase, SideloadRelatedTestMixin, Genera
 
         # used for assertion
         cls.primary_model_name = 'self'
+
+
+class TestDrfSideloadingNegative(BaseTestCase, SideloadRelatedTestMixin, GeneralTestMixin):
+    """ Test Cases of incorrect use of API """
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestDrfSideloadingNegative, cls).setUpClass()
+        # Define just serializer without indicate primary model
+        sideloadable_relations = {
+            'product': ProductSerializer,
+            'category': CategorySerializer,
+            'supplier': SupplierSerializer,
+            'partner': PartnerSerializer
+        }
+        ProductViewSet.sideloadable_relations = sideloadable_relations
+
+        # used for assertion
+        cls.primary_model_name = 'self'
+
+
+class TestDrfSideloadingPrimary(BaseTestCase, SideloadRelatedTestMixin, GeneralTestMixin):
+    """Define only primary True property for primary model"""
+
+    @classmethod
+    @unittest.skip("testing skipping")
+    def setUpClass(cls):
+        super(TestDrfSideloadingPrimary, cls).setUpClass()
+        sideloadable_relations = {
+            'product': {'primary': True},
+            'category': CategorySerializer,
+            'supplier': SupplierSerializer,
+            'partner': PartnerSerializer
+        }
+        ProductViewSet.sideloadable_relations = sideloadable_relations
+
+        cls.primary_model_name = 'product'
 
 
 class TestDrfSideloading(BaseTestCase, SideloadRelatedTestMixin, GeneralTestMixin):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,8 +7,6 @@ test_drf-sideloading
 
 Tests for `drf-sideloading` models api.
 """
-import unittest
-
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from rest_framework import status

--- a/tests/viewsets.py
+++ b/tests/viewsets.py
@@ -17,10 +17,8 @@ class ProductViewSet(SideloadableRelationsMixin, viewsets.ModelViewSet):
     queryset = Product.objects.all()
     serializer_class = ProductSerializer
 
-    base_model_name = 'product'
-
     sideloadable_relations = {
-        'product': ProductSerializer,
+        'product': {'primary': True, 'serializer': ProductSerializer},
         'category': CategorySerializer,
         'supplier': SupplierSerializer,
         'partner': PartnerSerializer


### PR DESCRIPTION
adds extra features and maintained simple interface as well.

Simples useless would be just defining relation names and serialisers

        sideloadable_relations = {
            'product': {'primary':True},
            'category': CategorySerializer,
            'supplier': SupplierSerializer,
            'partner': PartnerSerializer
        }


And another usecase to use dicts and define custom names and also mix both usecases

    sideloadable_relations = {
        'product': {'primary': True, 'serializer': ProductSerializer, 'name': 'products'},
        'category': {'serializer': CategorySerializer, 'name': 'categories'},
        'supplier': SupplierSerializer,
        'partner': PartnerSerializer
    }