### PR TITLE
Django 5 support

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-max-line-length = 130
+max-line-length = 120
 ignore = W503

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,13 @@ python:
   - "3.7"
   - "3.8"
   - "3.9"
+  - "3.10"
+  - "3.11"
 
 matrix:
   fast_finish: true
   include:
-    - python: 3.8
+    - python: 3.11
       env: TOXENV=lint
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,12 @@ python:
   - "3.9"
   - "3.10"
   - "3.11"
+  - "3.12"
 
 matrix:
   fast_finish: true
   include:
-    - python: 3.11
+    - python: 3.12
       env: TOXENV=lint
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.1.0 (2024-01-26)
+
+- Support for Django 4
+  - Django supported versions `4.0 -> 4.2`
+  - Python supported versions `3.10 -> 3.11`
+  - Django-rest-framework supported versions. `3.13 -> 3.14`
+- Fix issue with prefetch ordering
+
 ## 2.0.1 (2021-12-16)
 
 - Ensure that only allowed methods are sideloaded

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.1 (2024-01-??)
+
+- Add support for drf_spectacular documentation
+
 ## 2.1.0 (2024-01-26)
 
 - Support for Django 4

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 # Changelog
 
 
+## 2.2.0 (2024-10-??)
+- Support for Django 5
+  - Django supported versions `5.0 -> 5.1`
+  - Python supported versions `3.10 -> 3.12`
+  - Django-rest-framework supported versions. `3.15`
+
 ## 2.1.2 (2024-01-??)
 
 - Add support for request dependant prefetch filtering

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## 2.2.0 (2024-10-??)
+## 2.2.0 (2024-10-22)
 - Support for Django 5
   - Django supported versions `5.0 -> 5.1`
   - Python supported versions `3.10 -> 3.12`

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,7 @@
   - Python supported versions `3.10 -> 3.11`
   - Django-rest-framework supported versions. `3.13 -> 3.14`
 - Fix issue with prefetch ordering
+- Add prefetch related support for multi source fields
 
 ## 2.0.1 (2021-12-16)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,21 +1,15 @@
 # Changelog
 
-
 ## 2.2.0 (2024-10-22)
 - Support for Django 5
   - Django supported versions `5.0 -> 5.1`
   - Python supported versions `3.10 -> 3.12`
   - Django-rest-framework supported versions. `3.15`
-
-## 2.1.2 (2024-01-??)
-
 - Add support for request dependant prefetch filtering
 - refactored code for better readability
-- prefetches from view are also used when determining sideloading prefetches 
-
-## 2.1.1 (2024-01-??)
-
+- prefetches from view are also used when determining sideloading prefetches
 - Add support for drf_spectacular documentation
+- Add prefetch related support for multi source fields
 
 ## 2.1.0 (2024-01-26)
 
@@ -24,7 +18,6 @@
   - Python supported versions `3.10 -> 3.11`
   - Django-rest-framework supported versions. `3.13 -> 3.14`
 - Fix issue with prefetch ordering
-- Add prefetch related support for multi source fields
 
 ## 2.0.1 (2021-12-16)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,12 @@
 # Changelog
 
+
+## 2.1.2 (2024-01-??)
+
+- Add support for request dependant prefetch filtering
+- refactored code for better readability
+- prefetches from view are also used when determining sideloading prefetches 
+
 ## 2.1.1 (2024-01-??)
 
 - Add support for drf_spectacular documentation

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ DRF-sideloading is an extension to provide side-loading functionality of related
    Include **SideloadableRelationsMixin** mixin in ViewSet and define **sideloading_serializer_class** as shown in example below. 
    Everything else stays just like a regular ViewSet.
    Since version 2.0.0 there are 3 new methods that allow to overwrite the serializer used based on the request version for example
-   Since version 2.1.2 an additional method was added that allow to add request dependent filters to sideloaded relations
+   Since version 2.1.0 an additional method was added that allow to add request dependent filters to sideloaded relations
 
     ```python
     from drf_sideloading.mixins import SideloadableRelationsMixin

--- a/README.md
+++ b/README.md
@@ -145,11 +145,11 @@ DRF-sideloading is an extension to provide side-loading functionality of related
             # Add prefetches for the viewset as normal 
             return super().get_queryset().prefetch_related("created_by")
    
-        def get_sideloading_serializer_class(self):
+        def get_sideloading_serializer_class(self, request=None):
             # use a different sideloadable serializer for older version 
             if self.request.version < "1.0.0":
                 return OldProductSideloadableSerializer
-            return super().get_sideloading_serializer_class()
+            return super().get_sideloading_serializer_class(request=request)
    
         def get_sideloading_serializer(self, *args, **kwargs):
             # if modifications are required to the serializer initialization this method can be used.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ DRF-sideloading is an extension to provide side-loading functionality of related
    Include **SideloadableRelationsMixin** mixin in ViewSet and define **sideloading_serializer_class** as shown in example below. 
    Everything else stays just like a regular ViewSet.
    Since version 2.0.0 there are 3 new methods that allow to overwrite the serializer used based on the request version for example
+   Since version 2.1.2 an additional method was added that allow to add request dependent filters to sideloaded relations
 
     ```python
     from drf_sideloading.mixins import SideloadableRelationsMixin
@@ -157,6 +158,14 @@ DRF-sideloading is an extension to provide side-loading functionality of related
         def get_sideloading_serializer_context(self):
             # Extra context provided to the serializer class.
             return {"request": self.request, "format": self.format_kwarg, "view": self}
+      
+        def add_sideloading_prefetch_filter(self, source, queryset, request):
+             # 
+            if source == "model1__relation1":
+                return queryset.filter(is_active=True), True
+            if hasattr(queryset, "readable"):
+                return queryset.readable(user=request.user), True
+            return queryset, False
     ```
 
 6. Enjoy your API with sideloading support

--- a/drf_sideloading/mixins.py
+++ b/drf_sideloading/mixins.py
@@ -407,10 +407,8 @@ class SideloadableRelationsMixin(object):
                             ]:
                                 related_ids |= set(prefetched_data.values_list("id", flat=True))
                             elif isinstance(prefetched_data, models.Model):
-                                print("models.Model")
                                 related_ids.add(prefetched_data.id)
                             elif isinstance(prefetched_data, list):
-                                print(list)
                                 try:
                                     related_ids |= set(x.id for x in prefetched_data)
                                 except AttributeError:

--- a/drf_sideloading/mixins.py
+++ b/drf_sideloading/mixins.py
@@ -5,7 +5,7 @@ from itertools import chain
 from typing import Dict, Optional, Union, Set, List
 
 from django.db import models
-from django.db.models import Prefetch, QuerySet
+from django.db.models import Prefetch
 from django.db.models.fields.related_descriptors import (
     ForwardManyToOneDescriptor,
     ForwardOneToOneDescriptor,

--- a/drf_sideloading/mixins.py
+++ b/drf_sideloading/mixins.py
@@ -523,7 +523,7 @@ class SideloadableRelationsMixin(object):
                 if field_source:
                     # default to field source if not defined by user
                     cleaned_prefetches[relation] = [field_source]
-                elif getattr(self.primary_field.Meta.model, relation, None):
+                elif getattr(self.primary_field.child.Meta.model, relation, None):
                     # default to parent serializer model field with the relation name if it exists
                     cleaned_prefetches[relation] = [relation]
                 else:

--- a/drf_sideloading/mixins.py
+++ b/drf_sideloading/mixins.py
@@ -390,11 +390,10 @@ class SideloadableRelationsMixin(object):
             if isinstance(self.sideloadable_field_sources.get(relation), dict):
                 # Multi source relation
                 for src_key, source_prefetch in self.sideloadable_field_sources[relation].items():
-                    # if not (source_keys is None or src_key in source_keys or src_key == "__all__"):
-                    #     raise ValueError(f"Unexpected relation source '{src_key}' used")
-                    sideloadable_page[relation_key] |= self.filter_related_objects(
-                        related_objects=page, lookup=source_prefetch
-                    )
+                    if not source_keys or src_key in source_keys:
+                        sideloadable_page[relation_key] |= self.filter_related_objects(
+                            related_objects=page, lookup=source_prefetch
+                        )
             else:
                 sideloadable_page[relation_key] |= self.filter_related_objects(
                     related_objects=page, lookup=field_source or self.sideloadable_field_sources[relation]

--- a/drf_sideloading/mixins.py
+++ b/drf_sideloading/mixins.py
@@ -271,10 +271,12 @@ class SideloadableRelationsMixin(object):
         if not relations_to_sideload:
             try:
                 return super().retrieve(request=request, *args, **kwargs)
-            except AttributeError:
-                # self.retrieve() method was not declared before this mixin.
-                # Make sure the SideloadableRelationsMixin is defined higher than RetrieveModelMixin.
-                return self.http_method_not_allowed(request, *args, **kwargs)
+            except AttributeError as exc:
+                if "super' object has no attribute 'retrieve'" in exc.args[0]:
+                    # self.retrieve() method was not declared before this mixin.
+                    # Make sure the SideloadableRelationsMixin is defined higher than RetrieveModelMixin.
+                    return self.http_method_not_allowed(request, *args, **kwargs)
+                raise exc
 
         # return object with sideloading serializer
         queryset = self.get_sideloadable_object_as_queryset(
@@ -301,10 +303,12 @@ class SideloadableRelationsMixin(object):
         if not relations_to_sideload:
             try:
                 return super().list(request=request, *args, **kwargs)
-            except AttributeError:
-                # self.retrieve() method was not declared before this mixin.
-                # Make sure the SideloadableRelationsMixin is defined higher than RetrieveModelMixin.
-                return self.http_method_not_allowed(request, *args, **kwargs)
+            except AttributeError as exc:
+                if "super' object has no attribute 'list'" in exc.args[0]:
+                    # self.list() method was not declared before this mixin.
+                    # Make sure the SideloadableRelationsMixin is defined higher than ListModelMixin.
+                    return self.http_method_not_allowed(request, *args, **kwargs)
+                raise exc
 
         # After this `relations_to_sideload` is safe to use
         queryset = self.get_queryset()

--- a/drf_sideloading/mixins.py
+++ b/drf_sideloading/mixins.py
@@ -237,7 +237,7 @@ class SideloadableRelationsMixin(object):
         # After this `relations_to_sideload` is safe to use
         queryset = self.get_queryset()
         if prefetch_relations:
-            queryset = queryset.prefetch_related(*prefetch_relations.values())
+            queryset = queryset.prefetch_related(*[v for k, v in sorted(prefetch_relations.items())])
         queryset = self.filter_queryset(queryset)
 
         # Create page
@@ -361,7 +361,7 @@ class SideloadableRelationsMixin(object):
         )
 
         if prefetch_relations:
-            queryset = queryset.prefetch_related(*prefetch_relations.values())
+            queryset = queryset.prefetch_related(*[v for k, v in sorted(prefetch_relations.items())])
         queryset = self.filter_queryset(queryset)
 
         # Perform the lookup filtering.

--- a/drf_sideloading/mixins.py
+++ b/drf_sideloading/mixins.py
@@ -81,7 +81,7 @@ class SideloadableRelationsMixin(object):
             return {}
 
         relations_to_sideload = {}
-        for param in re.split(",\s*(?![^\[\]]*\])", sideload_parameter):
+        for param in re.split(r",\s*(?![^\[\]]*\])", sideload_parameter):
             if not param:
                 continue
             try:
@@ -560,8 +560,8 @@ class SideloadableRelationsMixin(object):
                         data_source = relation
                     else:
                         raise ValueError(
-                            f"Unless source is defined or the field name matches the model, "
-                            f"there can only be one prefetch, to define the relation"
+                            "Unless source is defined or the field name matches the model, "
+                            "there can only be one prefetch, to define the relation"
                         )
                 elif isinstance(relation_prefetches[0], str):
                     data_source = relation_prefetches[0]
@@ -569,8 +569,8 @@ class SideloadableRelationsMixin(object):
                     data_source = relation_prefetches[0].to_attr or relation_prefetches[0].prefetch_through
                 else:
                     raise ValueError(
-                        f"Unless source is defined or the field name matches the model, "
-                        f"There can only be one prefetch, to define the relation and it must be a string or Prefetch"
+                        "Unless source is defined or the field name matches the model, "
+                        "There can only be one prefetch, to define the relation and it must be a string or Prefetch"
                     )
 
                 if any(isinstance(prefetch, Prefetch) for prefetch in relation_prefetches):
@@ -596,8 +596,8 @@ class SideloadableRelationsMixin(object):
                             data_source = relation
                         else:
                             raise ValueError(
-                                f"Unless source is defined or the field name matches the model, "
-                                f"there can only be one prefetch, to define the relation"
+                                "Unless source is defined or the field name matches the model, "
+                                "there can only be one prefetch, to define the relation"
                             )
 
                     for prefetch in relation_prefetches:
@@ -624,7 +624,7 @@ class SideloadableRelationsMixin(object):
                 elif relation_prefetches:
                     requested_sources = list(relation_prefetches.keys())
                 else:
-                    raise ValueError(f"Prefetches missing")
+                    raise ValueError("Prefetches missing")
 
                 # collect field prefetches and sources
                 relations_sources[relation] = dict()

--- a/drf_sideloading/mixins.py
+++ b/drf_sideloading/mixins.py
@@ -625,7 +625,6 @@ class SideloadableRelationsMixin(object):
         if not existing_prefetch:
             prefetches[prefetch_attr] = prefetch
         elif isinstance(existing_prefetch, str):
-            # fixme: Check if different filters where applied to Prefetch queryset.
             if isinstance(prefetch, str):
                 if prefetch != existing_prefetch:
                     raise ValueError("Got different string prefetches to the same attribute name")

--- a/drf_sideloading/mixins.py
+++ b/drf_sideloading/mixins.py
@@ -62,7 +62,9 @@ class SideloadableRelationsMixin(object):
             sideload_parameter=request.query_params.get(self.sideloading_query_param_name, ""),
         )
         self.check_sideload_params(
-            relations_to_sideload=relations_to_sideload, sideloadable_fields=sideloadable_fields, prefetches=prefetches
+            relations_to_sideload=relations_to_sideload,
+            sideloadable_fields=sideloadable_fields,
+            prefetches=prefetches,
         )
 
         # find applicable prefetches
@@ -361,7 +363,8 @@ class SideloadableRelationsMixin(object):
                     sideloadable_page[relation_key] |= self.filter_related_objects(related_objects=page, lookup=src)
             else:
                 sideloadable_page[relation_key] |= self.filter_related_objects(
-                    related_objects=page, lookup=field_source or relations_sources[relation]
+                    related_objects=page,
+                    lookup=field_source or relations_sources[relation],
                 )
 
         return sideloadable_page
@@ -499,7 +502,10 @@ class SideloadableRelationsMixin(object):
                     raise ValueError(f"Either source or prefetches must be set for sideloadable field '{relation}'")
             elif isinstance(user_prefetches, (str, list, Prefetch)):
                 cleaned_prefetches[relation] = self._clean_prefetches(
-                    field=field, relation=relation, value=user_prefetches, ensure_list=True
+                    field=field,
+                    relation=relation,
+                    value=user_prefetches,
+                    ensure_list=True,
                 )
             elif isinstance(user_prefetches, dict):
                 # This is a multi source field!
@@ -507,7 +513,10 @@ class SideloadableRelationsMixin(object):
                 cleaned_prefetches[relation] = {}
                 for rel, rel_prefetches in user_prefetches.items():
                     relation_prefetches = self._clean_prefetches(
-                        field=field, relation=rel, value=rel_prefetches, ensure_list=True
+                        field=field,
+                        relation=rel,
+                        value=rel_prefetches,
+                        ensure_list=True,
                     )
                     cleaned_prefetches[relation][rel] = relation_prefetches
             else:
@@ -649,36 +658,36 @@ class SideloadableRelationsMixin(object):
                 else:
                     raise ValueError("Prefetches missing")
 
-                    # collect field prefetches and sources
-                    relations_sources[relation] = dict()
-                    for source_key in requested_sources:
-                        if relations_sources[relation].get(source_key):
+                # collect field prefetches and sources
+                relations_sources[relation] = dict()
+                for source_key in requested_sources:
+                    if relations_sources[relation].get(source_key):
+                        raise ValueError(
+                            "Multiple sources defined for single multi source field. "
+                            "Prefetch or select related within Prefetch queryset."
+                        )
+                    source_prefetches = relation_prefetches[source_key]
+                    if not isinstance(source_prefetches, list):
+                        source_prefetches = [source_prefetches]
+
+                    if any(isinstance(prefetch, Prefetch) for prefetch in source_prefetches):
+                        # load data from Prefetch.to_attr object used
+                        if len(source_prefetches) != 1:
                             raise ValueError(
-                                "Multiple sources defined for single multi source field. "
-                                "Prefetch or select related within Prefetch queryset."
-                            )
-                        source_prefetches = relation_prefetches[source_key]
-                        if not isinstance(source_prefetches, list):
-                            source_prefetches = [source_prefetches]
-
-                        if any(isinstance(prefetch, Prefetch) for prefetch in source_prefetches):
-                            # load data from Prefetch.to_attr object used
-                            if len(source_prefetches) != 1:
-                                raise ValueError(
-                                    "If Prefetch is used, there can only one prefetch. "
-                                    "Others must be defined within Prefetch.queryset"
-                                )
-
-                        # This adds all of the required prefetches to prefetches list
-                        source_prefetch_attrs = []
-                        for source_prefetch in source_prefetches:
-                            source_prefetch_attrs.append(
-                                self._add_prefetch(prefetches=gathered_prefetches, prefetch=source_prefetch)
+                                "If Prefetch is used, there can only one prefetch. "
+                                "Others must be defined within Prefetch.queryset"
                             )
 
-                        # This adds the key to what resource needs to be loaded for each source
-                        # Note: sort the source perefetch attrs so that the actual source will be the first one.
-                        relations_sources[relation][source_key] = sorted(source_prefetch_attrs)[0]
+                    # This adds all of the required prefetches to prefetches list
+                    source_prefetch_attrs = []
+                    for source_prefetch in source_prefetches:
+                        source_prefetch_attrs.append(
+                            self._add_prefetch(prefetches=gathered_prefetches, prefetch=source_prefetch)
+                        )
+
+                    # This adds the key to what resource needs to be loaded for each source
+                    # Note: sort the source perefetch attrs so that the actual source will be the first one.
+                    relations_sources[relation][source_key] = sorted(source_prefetch_attrs)[0]
             else:
                 raise NotImplementedError(
                     f"Sideloading with prefetch type {type(relation_prefetches)} has not been implemented"

--- a/drf_sideloading/mixins.py
+++ b/drf_sideloading/mixins.py
@@ -1,10 +1,16 @@
 import copy
 import re
-import importlib
 from itertools import chain
-from typing import Dict, Optional, Union, Tuple, Set, List
+from typing import Dict, Optional, Union, Set, List
 
 from django.db.models import Prefetch
+from django.db.models.fields.related_descriptors import (
+    ForwardManyToOneDescriptor,
+    ForwardOneToOneDescriptor,
+    ReverseOneToOneDescriptor,
+    ReverseManyToOneDescriptor,
+)
+from django.db.models.sql.where import WhereNode, AND
 from django.utils.translation import gettext_lazy as _
 from rest_framework.exceptions import ValidationError
 from rest_framework.generics import get_object_or_404
@@ -14,80 +20,99 @@ from rest_framework.serializers import ListSerializer
 
 from drf_sideloading.serializers import SideLoadableSerializer
 
+RELATION_DESCRIPTORS = [
+    ForwardManyToOneDescriptor,
+    ForwardOneToOneDescriptor,
+    ReverseOneToOneDescriptor,
+    ReverseManyToOneDescriptor,
+]
+
+
+def contains_where_node(existing_node: WhereNode, new_node: WhereNode) -> bool:
+    """
+    Checks if the existing_node contains the new_node.
+    It will no check OR conditions however!
+    """
+    if not isinstance(new_node, WhereNode):
+        raise ValueError("new_node has to be a WhereNode instance")
+    if not isinstance(existing_node, WhereNode):
+        return False
+    if not set(new_node.children) - set(existing_node.children):  # all new node children applied
+        return True
+    if existing_node.connector == AND:
+        for child_node in existing_node.children:
+            exists = contains_where_node(child_node, new_node)
+            if exists:
+                return True
+    return False
+
 
 class SideloadableRelationsMixin(object):
     sideloading_query_param_name = "sideload"
     sideloading_serializer_class = None
-    if importlib.util.find_spec("drf_spectacular") is not None:
-        from drf_sideloading.schema import SideloadingAutoSchema
+    primary_field_name: str = None
+    sideloadable_fields: Dict = {}
+    user_defined_prefetches: Dict = {}
+    primary_field = None
+    sideloadable_field_sources: Dict = {}
 
-        # note: if required, the user can overwrite the schema
-        schema = SideloadingAutoSchema()
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.check_sideloading_serializer_class(self.sideloading_serializer_class)
 
-    def get_sideloading_keys_sources(self) -> Dict[str, List[str]]:
-        sideloading_serializer_class = self.get_sideloading_serializer_class()
-        primary_field_name = sideloading_serializer_class.Meta.primary
-        sideloadable_fields = copy.deepcopy(sideloading_serializer_class._declared_fields)
-        sideloadable_fields.pop(primary_field_name)
-        # cleaned prefetches
-        prefetches = self._gather_all_prefetches(
-            sideloadable_fields=sideloadable_fields,
-            user_defined_prefetches=getattr(sideloading_serializer_class.Meta, "prefetches", None),
-        )
+    def initialize_serializer(self, request):
+        sideloading_serializer_class = self.get_sideloading_serializer_class(request=request)
+        self.check_sideloading_serializer_class(sideloading_serializer_class)
 
-        # gather sideliadabled from prefetched first as it determines if its a multi source sideloading
-        sideloading_keys_sources = {k: [] for k in sideloadable_fields}
-        if isinstance(prefetches, dict):
-            for key, key_prefetches in prefetches.items():
-                if isinstance(key_prefetches, dict):
-                    sideloading_keys_sources[key] = list(key_prefetches.keys())
-
-        return sideloading_keys_sources
-
-    # fixme: This is an awkward method
-    def get_sideloading_variables_from_serializer(self, request):
-        sideloading_serializer_class = self.get_sideloading_serializer_class()
-        self.check_sideloading_serializer_class(serializer_class=sideloading_serializer_class)
-        # primary field
-        primary_field_name = sideloading_serializer_class.Meta.primary
         # sideloadable fields
-        sideloadable_fields = copy.deepcopy(sideloading_serializer_class._declared_fields)
-        sideloadable_fields.pop(primary_field_name)
-        # cleaned prefetches
-        prefetches = self._gather_all_prefetches(
-            sideloadable_fields=sideloadable_fields,
-            user_defined_prefetches=getattr(sideloading_serializer_class.Meta, "prefetches", None),
-        )
-        relations_to_sideload = self.parse_query_param(
-            sideload_parameter=request.query_params.get(self.sideloading_query_param_name, ""),
-        )
-        self.check_sideload_params(
-            relations_to_sideload=relations_to_sideload,
-            sideloadable_fields=sideloadable_fields,
-            prefetches=prefetches,
-        )
+        self.sideloadable_fields = copy.deepcopy(sideloading_serializer_class._declared_fields)
+        self.primary_field_name = sideloading_serializer_class.Meta.primary
+        self.primary_field = self.sideloadable_fields.pop(self.primary_field_name)
+        self.primary_model = self.primary_field.child.Meta.model
 
-        # find applicable prefetches
-        if relations_to_sideload:
-            prefetch_relations, relations_sources = self._get_relevant_prefetches(
-                sideloadable_fields=sideloadable_fields,
-                relations_to_sideload=relations_to_sideload,
-                cleaned_prefetches=prefetches,
-            )
-        else:
-            prefetch_relations = None
-            relations_sources = None
-        return (
-            sideloading_serializer_class,
-            primary_field_name,
-            sideloadable_fields,
-            prefetches,
-            relations_to_sideload,
-            prefetch_relations,
-            relations_sources,
-        )
+        # fetch sideloading sources and prefetches
+        self.user_defined_prefetches = getattr(sideloading_serializer_class.Meta, "prefetches", {})
+        self.sideloadable_field_sources = self.get_sideloading_field_sources()
 
-    def parse_query_param(self, sideload_parameter: str) -> Dict:
+    def get_source_from_prefetch(self, prefetches: str | List | Dict):
+        if isinstance(prefetches, str):
+            return prefetches
+        if isinstance(prefetches, Prefetch):
+            return prefetches.to_attr or prefetches.prefetch_through
+        elif isinstance(prefetches, dict):
+            if any(isinstance(v, dict) for v in prefetches.values()):
+                raise ValueError("Can't find source to_attr from dict.")
+            return {k: self.get_source_from_prefetch(v) for k, v in prefetches.items()}
+        elif isinstance(prefetches, list):
+            if not all(isinstance(v, (str, Prefetch)) for v in prefetches):
+                raise ValueError("Can't find source to_attr from list not containing only strings or prefetches.")
+            return sorted(self.get_source_from_prefetch(v) for v in prefetches)[0]
+
+    def get_sideloading_field_sources(self) -> Dict:
+        relations_sources = {}
+
+        for relation, field in self.sideloadable_fields.items():
+            relation_prefetches = self.user_defined_prefetches.get(relation)
+            sideloadable_field_source = field.child.source
+
+            # its a MultiSource field, fetch values from sources defined with prefetches.
+            if isinstance(relation_prefetches, dict) and sideloadable_field_source:
+                raise ValueError("Multi source field with source defined in serializer.")
+
+            if relation_prefetches:
+                data_source = self.get_source_from_prefetch(relation_prefetches)
+            elif sideloadable_field_source:
+                data_source = sideloadable_field_source
+            elif isinstance(getattr(self.primary_model, relation), tuple(RELATION_DESCRIPTORS)):
+                data_source = relation
+            else:
+                raise ValueError(f"Could not determine source for field '{relation}'.")
+
+            relations_sources[relation] = data_source
+
+        return relations_sources
+
+    def get_relations_to_sideload(self, request) -> Dict | None:
         """
         Parse query param and take validated names
 
@@ -102,47 +127,64 @@ class SideloadableRelationsMixin(object):
         response changed to dict as the sources for multi source fields must be selectable.
 
         """
+        if request.method != "GET":
+            return None
+
+        if self.sideloading_query_param_name not in request.query_params:
+            return None
+
+        sideload_parameter = request.query_params[self.sideloading_query_param_name]
         if not sideload_parameter:
-            return {}
+            return None
+            # raise ValidationError({self.sideloading_query_param_name: [_(f"'{relation}' Can not be blank.")]})
+
+        # This fetches the correct serializer and prepares sideloadable_fields ect.
+        self.initialize_serializer(request=request)
 
         relations_to_sideload = {}
-        for param in re.split(r",\s*(?![^\[\]]*\])", sideload_parameter):
-            if not param:
-                continue
-            try:
+        for param in re.split(",\s*(?![^\[\]]*\])", sideload_parameter):
+            if "[" in param:
                 fieldname, sources_str = param.split("[", 1)
+                if not sources_str.strip("]"):
+                    msg = _(f"'{fieldname}' source can not be empty.")
+                    raise ValidationError({self.sideloading_query_param_name: [msg]})
                 relations = set(sources_str.strip("]").split(","))
-                if any(relations):
-                    relations_to_sideload[fieldname] = set(sources_str.strip("]").split(","))
-            except ValueError:
-                relations_to_sideload[param] = None
+            else:
+                fieldname = param
+                relations = None
+
+            if fieldname not in self.sideloadable_fields:
+                msg = _(f"'{fieldname}' is not one of the available choices.")
+                raise ValidationError({self.sideloading_query_param_name: [msg]})
+
+            # check for source selection. select all if nothing given
+            if isinstance(self.user_defined_prefetches.get(fieldname), dict):
+                source_relations = sorted(self.user_defined_prefetches[fieldname].keys())
+                if relations is None:
+                    relations = source_relations
+                else:
+                    # Check if all requested sources are defined
+                    invalid_sources = set(relations) - set(source_relations)
+                    if invalid_sources:
+                        msg = _(f"'{fieldname}' sources {', '.join(invalid_sources)} are not defined.")
+                        raise ValidationError({self.sideloading_query_param_name: [msg]})
+            elif relations:
+                msg = _(f"'{fieldname}' is not a multi source field.")
+                raise ValidationError({self.sideloading_query_param_name: [msg]})
+
+            # everything checks out.
+            relations_to_sideload[fieldname] = relations
 
         return relations_to_sideload
 
-    def check_sideload_params(self, relations_to_sideload: Dict, sideloadable_fields: Dict, prefetches: Dict):
-        for relation, source_keys in relations_to_sideload.items():
-            if relation not in sideloadable_fields:
-                msg = _(f"'{relation}' is not one of the available choices.")
-                raise ValidationError({self.sideloading_query_param_name: [msg]})
-            if source_keys is not None:
-                if not isinstance(source_keys, (set, list)):
-                    raise ValueError(f"Source_keys must be a list or set not '{type(source_keys)}'")
-                if not isinstance(prefetches.get(relation), dict):
-                    msg = _(f"'{relation}' does not have multiple sources")
-                    raise ValidationError({self.sideloading_query_param_name: [msg]})
-                for source_key in source_keys:
-                    if source_key not in prefetches[relation].keys():
-                        msg = _(f"'{source_key}' is not one of the available source keys for relation '{relation}'")
-                        raise ValidationError({self.sideloading_query_param_name: [msg]})
-
-    def check_sideloading_serializer_class(self, serializer_class):
-        if not serializer_class:
+    def check_sideloading_serializer_class(self, sideloading_serializer_class):
+        if not sideloading_serializer_class:
             raise ValueError(f"'{self.__class__.__name__}' sideloading_serializer_class not found")
-        if not issubclass(serializer_class, SideLoadableSerializer):
+        if not issubclass(sideloading_serializer_class, SideLoadableSerializer):
             raise ValueError(
                 f"'{self.__class__.__name__}' sideloading_serializer_class must be a SideLoadableSerializer subclass"
             )
-        serializer_class.check_setup()
+        sideloading_serializer_class.check_setup()
 
     def get_sideloading_serializer(self, *args, **kwargs):
         """
@@ -152,7 +194,7 @@ class SideloadableRelationsMixin(object):
         kwargs["context"] = self.get_sideloading_serializer_context()
         return sideloading_serializer_class(*args, **kwargs)
 
-    def get_sideloading_serializer_class(self):
+    def get_sideloading_serializer_class(self, request=None):
         """
         Return the class to use for the sideloading_serializer.
         Defaults to using `self.sideloading_serializer_class`.
@@ -175,6 +217,49 @@ class SideloadableRelationsMixin(object):
         """
         return {"request": self.request, "format": self.format_kwarg, "view": self}
 
+    def get_sideloadable_queryset(self, prefetch):
+        if isinstance(prefetch, str):
+            model = self.primary_model
+            for x in prefetch.split("__"):
+                descriptor = getattr(model, x)
+                if isinstance(descriptor, ForwardManyToOneDescriptor):
+                    model = descriptor.field.remote_field.model
+                elif isinstance(descriptor, ForwardOneToOneDescriptor):
+                    model = descriptor.field.remote_field.model
+                elif isinstance(descriptor, ReverseOneToOneDescriptor):
+                    model = descriptor.related.related_model
+                elif isinstance(descriptor, ReverseManyToOneDescriptor):
+                    model = descriptor.field.model
+                else:
+                    raise NotImplementedError(f"Descriptor {descriptor.__class__.__name__} has not been implemented")
+            return model.objects.all()
+        elif isinstance(prefetch, Prefetch):
+            return prefetch.queryset
+        else:
+            raise NotImplementedError(f"finding queryset for prefetch type {type(prefetch)} has not been implemented")
+
+    def add_sideloading_prefetches(self, queryset, request, relations_to_sideload):
+        # Iterate over the prefetches of the original queryset and modify them
+        view_prefetches = {}
+        for prefetch in queryset._prefetch_related_lookups:
+            self._add_prefetch(prefetches=view_prefetches, prefetch=prefetch, request=request)
+        original_prefetches = [v for k, v in sorted(view_prefetches.items())]
+
+        # find applicable prefetches
+        gathered_prefetches = self._get_relevant_prefetches(
+            relations_to_sideload=relations_to_sideload,
+            gathered_prefetches=view_prefetches,
+            request=request,
+        )
+
+        # replace prefetches if any change made
+        prefetches = [v for k, v in sorted(gathered_prefetches.items())]
+        if prefetches != original_prefetches:
+            if original_prefetches:
+                queryset = queryset.prefetch_related(None)
+            queryset = queryset.prefetch_related(*prefetches)
+        return queryset
+
     # modified DRF methods
 
     def retrieve(self, request, *args, **kwargs):
@@ -182,24 +267,7 @@ class SideloadableRelationsMixin(object):
             # The viewset does not have RetrieveModelMixin and therefore the method is not allowed
             return self.http_method_not_allowed(request, *args, **kwargs)
 
-        if self.sideloading_query_param_name not in request.query_params:
-            try:
-                return super().retrieve(request=request, *args, **kwargs)
-            except AttributeError:
-                # self.retrieve() method was not declared before this mixin.
-                # Make sure the SideloadableRelationsMixin is defined higher than RetrieveModelMixin.
-                return self.http_method_not_allowed(request, *args, **kwargs)
-
-        (
-            sideloading_serializer_class,
-            primary_field_name,
-            sideloadable_fields,
-            prefetches,
-            relations_to_sideload,
-            prefetch_relations,
-            relations_sources,
-        ) = self.get_sideloading_variables_from_serializer(request=request)
-
+        relations_to_sideload = self.get_relations_to_sideload(request=request)
         if not relations_to_sideload:
             try:
                 return super().retrieve(request=request, *args, **kwargs)
@@ -209,17 +277,13 @@ class SideloadableRelationsMixin(object):
                 return self.http_method_not_allowed(request, *args, **kwargs)
 
         # return object with sideloading serializer
-        queryset, relations_sources = self.get_sideloadable_object_as_queryset(
+        queryset = self.get_sideloadable_object_as_queryset(
+            request=request,
             relations_to_sideload=relations_to_sideload,
-            sideloadable_fields=sideloadable_fields,
-            cleaned_prefetches=prefetches,
         )
         sideloadable_page = self.get_sideloadable_page_from_queryset(
             queryset=queryset,
-            primary_field_name=primary_field_name,
-            sideloadable_fields=sideloadable_fields,
             relations_to_sideload=relations_to_sideload,
-            relations_sources=relations_sources,
         )
         serializer = self.get_sideloading_serializer(
             instance=sideloadable_page,
@@ -233,36 +297,22 @@ class SideloadableRelationsMixin(object):
             # The viewset does not have ListModelMixin and therefore the method is not allowed
             return self.http_method_not_allowed(request, *args, **kwargs)
 
-        if request.method != "GET" or self.sideloading_query_param_name not in request.query_params:
-            try:
-                return super().list(request=request, *args, **kwargs)
-            except AttributeError:
-                # self.list() method was not declared before this mixin.
-                # Make sure the SideloadableRelationsMixin is defined higher than ListModelMixin.
-                return self.http_method_not_allowed(request, *args, **kwargs)
-
-        (
-            sideloading_serializer_class,
-            primary_field_name,
-            sideloadable_fields,
-            prefetches,
-            relations_to_sideload,
-            prefetch_relations,
-            relations_sources,
-        ) = self.get_sideloading_variables_from_serializer(request=request)
-
+        relations_to_sideload = self.get_relations_to_sideload(request=request)
         if not relations_to_sideload:
             try:
                 return super().list(request=request, *args, **kwargs)
             except AttributeError:
-                # self.list() method was not declared before this mixin.
-                # Make sure the SideloadableRelationsMixin is defined higher than ListModelMixin.
+                # self.retrieve() method was not declared before this mixin.
+                # Make sure the SideloadableRelationsMixin is defined higher than RetrieveModelMixin.
                 return self.http_method_not_allowed(request, *args, **kwargs)
 
         # After this `relations_to_sideload` is safe to use
         queryset = self.get_queryset()
-        if prefetch_relations:
-            queryset = queryset.prefetch_related(*[v for k, v in sorted(prefetch_relations.items())])
+        queryset = self.add_sideloading_prefetches(
+            queryset=queryset,
+            request=request,
+            relations_to_sideload=relations_to_sideload,
+        )
         queryset = self.filter_queryset(queryset)
 
         # Create page
@@ -270,10 +320,7 @@ class SideloadableRelationsMixin(object):
         if page is not None:
             sideloadable_page = self.get_sideloadable_page(
                 page=page,
-                primary_field_name=primary_field_name,
-                sideloadable_fields=sideloadable_fields,
                 relations_to_sideload=relations_to_sideload,
-                relations_sources=relations_sources,
             )
             serializer = self.get_sideloading_serializer(
                 instance=sideloadable_page,
@@ -284,10 +331,7 @@ class SideloadableRelationsMixin(object):
         else:
             sideloadable_page = self.get_sideloadable_page_from_queryset(
                 queryset=queryset,
-                primary_field_name=primary_field_name,
-                sideloadable_fields=sideloadable_fields,
                 relations_to_sideload=relations_to_sideload,
-                relations_sources=relations_sources,
             )
             serializer = self.get_sideloading_serializer(
                 instance=sideloadable_page,
@@ -296,14 +340,7 @@ class SideloadableRelationsMixin(object):
             )
             return Response(serializer.data)
 
-    def get_sideloadable_page_from_queryset(
-        self,
-        queryset,
-        primary_field_name: str,
-        sideloadable_fields: Dict,
-        relations_to_sideload: Dict,
-        relations_sources: Dict,
-    ):
+    def get_sideloadable_page_from_queryset(self, queryset, relations_to_sideload: Dict):
         """
         Populates page with sideloaded data by collecting ids form sideloaded values and then making into a query
         """
@@ -311,41 +348,36 @@ class SideloadableRelationsMixin(object):
         if not relations_to_sideload:
             raise ValueError("relations_to_sideload is required")
         # this works wonders, but can't be used when page is paginated...
-        sideloadable_page = {primary_field_name: queryset}
+        sideloadable_page = {self.primary_field_name: queryset}
 
         for relation, source_keys in relations_to_sideload.items():
-            field = sideloadable_fields[relation]
+            field = self.sideloadable_fields[relation]
             field_source = field.child.source
             source_model = field.child.Meta.model
             relation_key = field_source or relation
 
             related_ids = set()
-            if isinstance(relations_sources.get(relation), dict):
-                for src_key, src in relations_sources[relation].items():
+            if isinstance(self.sideloadable_field_sources.get(relation), dict):
+                for src_key, src in self.sideloadable_field_sources[relation].items():
                     if not (source_keys is None or src_key in source_keys or src_key == "__all__"):
                         raise ValueError(f"Unexpected relation source '{src_key}' used")
                     related_ids |= set(queryset.values_list(src, flat=True))
             else:
-                related_ids |= set(queryset.values_list(field_source or relations_sources[relation], flat=True))
+                related_ids |= set(
+                    queryset.values_list(field_source or self.sideloadable_field_sources[relation], flat=True)
+                )
 
             sideloadable_page[relation_key] = source_model.objects.filter(id__in=related_ids)
 
         return sideloadable_page
 
-    def get_sideloadable_page(
-        self,
-        page,
-        primary_field_name: str,
-        sideloadable_fields: Dict,
-        relations_to_sideload: Dict,
-        relations_sources: Dict,
-    ):
+    def get_sideloadable_page(self, page, relations_to_sideload: Dict):
         """
         Populates page with sideloaded data by collecting distinct values form sideloaded data
         """
-        sideloadable_page = {primary_field_name: page}
+        sideloadable_page = {self.primary_field_name: page}
         for relation, source_keys in relations_to_sideload.items():
-            field = sideloadable_fields[relation]
+            field = self.sideloadable_fields[relation]
             field_source = field.child.source
             relation_key = field_source or relation
 
@@ -355,21 +387,22 @@ class SideloadableRelationsMixin(object):
             if relation not in sideloadable_page:
                 sideloadable_page[relation_key] = set()
 
-            if isinstance(relations_sources.get(relation), dict):
+            if isinstance(self.sideloadable_field_sources.get(relation), dict):
                 # Multi source relation
-                for src_key, src in relations_sources[relation].items():
-                    if not (source_keys is None or src_key in source_keys or src_key == "__all__"):
-                        raise ValueError(f"Unexpected relation source '{src_key}' used")
-                    sideloadable_page[relation_key] |= self.filter_related_objects(related_objects=page, lookup=src)
+                for src_key, source_prefetch in self.sideloadable_field_sources[relation].items():
+                    # if not (source_keys is None or src_key in source_keys or src_key == "__all__"):
+                    #     raise ValueError(f"Unexpected relation source '{src_key}' used")
+                    sideloadable_page[relation_key] |= self.filter_related_objects(
+                        related_objects=page, lookup=source_prefetch
+                    )
             else:
                 sideloadable_page[relation_key] |= self.filter_related_objects(
-                    related_objects=page,
-                    lookup=field_source or relations_sources[relation],
+                    related_objects=page, lookup=field_source or self.sideloadable_field_sources[relation]
                 )
 
         return sideloadable_page
 
-    def get_sideloadable_object_as_queryset(self, relations_to_sideload, sideloadable_fields, cleaned_prefetches):
+    def get_sideloadable_object_as_queryset(self, request, relations_to_sideload):
         """
         mimics DRF original method get_object()
         Returns the object the view is displaying with sideloaded models prefetched.
@@ -380,14 +413,11 @@ class SideloadableRelationsMixin(object):
         """
         # Add prefetches if applicable
         queryset = self.get_queryset()
-        prefetch_relations, relations_sources = self._get_relevant_prefetches(
-            sideloadable_fields=sideloadable_fields,
+        queryset = self.add_sideloading_prefetches(
+            queryset=queryset,
+            request=request,
             relations_to_sideload=relations_to_sideload,
-            cleaned_prefetches=cleaned_prefetches,
         )
-
-        if prefetch_relations:
-            queryset = queryset.prefetch_related(*[v for k, v in sorted(prefetch_relations.items())])
         queryset = self.filter_queryset(queryset)
 
         # Perform the lookup filtering.
@@ -407,7 +437,7 @@ class SideloadableRelationsMixin(object):
         # May raise a permission denied
         self.check_object_permissions(self.request, obj)
 
-        return queryset, relations_sources
+        return queryset
 
     def filter_related_objects(self, related_objects, lookup: Optional[str]) -> Set:
         current_lookup, remaining_lookup = lookup.split("__", 1) if "__" in lookup else (lookup, None)
@@ -417,6 +447,7 @@ class SideloadableRelationsMixin(object):
 
         if lookup_values:
             if lookup_values[0].__class__.__name__ in ["ManyRelatedManager", "RelatedManager"]:
+                # FIXME: apply filtering here!
                 related_objects_set = set(chain(*[related_queryset.all() for related_queryset in lookup_values]))
             elif isinstance(lookup_values[0], list):
                 related_objects_set = set(chain(*[related_list for related_list in lookup_values]))
@@ -473,39 +504,33 @@ class SideloadableRelationsMixin(object):
 
         return cleaned_value
 
-    def _gather_all_prefetches(self, sideloadable_fields: Dict, user_defined_prefetches: Optional[Dict]) -> Dict:
+    def _gather_all_prefetches(self) -> Dict:
         """
         this method finds all prefetches required and checks if they are correctly defined
         """
         cleaned_prefetches = {}
 
-        if not sideloadable_fields:
+        if not self.sideloadable_fields:
             raise ValueError("'sideloadable_fields' is a required argument")
 
-        if not user_defined_prefetches:
-            user_defined_prefetches = {}
-
         # find prefetches for all sideloadable relations
-        for relation, field in sideloadable_fields.items():
-            user_prefetches = user_defined_prefetches.get(relation)
+        for relation, field in self.sideloadable_fields.items():
+            user_prefetches = self.user_defined_prefetches.get(relation)
             field_source = field.child.source
-            if relation in user_defined_prefetches and not user_prefetches:
+            if relation in self.user_defined_prefetches and not user_prefetches:
                 raise ValueError(f"prefetches for field '{relation}' have been left empty")
             elif not user_prefetches:
                 if field_source:
                     # default to field source if not defined by user
                     cleaned_prefetches[relation] = [field_source]
-                elif getattr(self.get_serializer_class().Meta.model, relation, None):
+                elif getattr(self.primary_field.Meta.model, relation, None):
                     # default to parent serializer model field with the relation name if it exists
                     cleaned_prefetches[relation] = [relation]
                 else:
                     raise ValueError(f"Either source or prefetches must be set for sideloadable field '{relation}'")
             elif isinstance(user_prefetches, (str, list, Prefetch)):
                 cleaned_prefetches[relation] = self._clean_prefetches(
-                    field=field,
-                    relation=relation,
-                    value=user_prefetches,
-                    ensure_list=True,
+                    field=field, relation=relation, value=user_prefetches, ensure_list=True
                 )
             elif isinstance(user_prefetches, dict):
                 # This is a multi source field!
@@ -513,10 +538,7 @@ class SideloadableRelationsMixin(object):
                 cleaned_prefetches[relation] = {}
                 for rel, rel_prefetches in user_prefetches.items():
                     relation_prefetches = self._clean_prefetches(
-                        field=field,
-                        relation=rel,
-                        value=rel_prefetches,
-                        ensure_list=True,
+                        field=field, relation=rel, value=rel_prefetches, ensure_list=True
                     )
                     cleaned_prefetches[relation][rel] = relation_prefetches
             else:
@@ -524,46 +546,118 @@ class SideloadableRelationsMixin(object):
 
         return cleaned_prefetches
 
-    def _add_prefetch(self, prefetches: Dict, prefetch: Union[str, Prefetch]) -> str:
+    def add_sideloading_prefetch_filter(self, source, queryset, request):
+        """
+        This method is intended to e overwritten in case the user wants to implement
+        their own filters based on the related model or the relationship to the base model
+
+        source - string path to the value that is sideloded.
+        queryset - QuerySet that you can add filtering to
+
+        Example:
+
+        add_sideloading_prefetch_filter(self, source, queryset, request):
+            if source == "model1__relation1":
+                return queryset.filter(is_active=True), True
+            if hasattr(queryset, "readable"):
+                return queryset.readable(user=request.user), True
+            return queryset, False
+
+        """
+
+        return queryset, False
+
+    def _add_sideloading_filter(self, prefetch: str | Prefetch, request) -> str | Prefetch:
+        # fetch sideloadable source and queryset
+        prefetch_source = self.get_source_from_prefetch(prefetches=prefetch)
+        prefetch_queryset = self.get_sideloadable_queryset(prefetch)
+        filtered_queryset, added = self.add_sideloading_prefetch_filter(
+            source=prefetch_source, queryset=prefetch_queryset, request=request
+        )
+        if added:
+            filter_node = self.add_sideloading_prefetch_filter(
+                source=prefetch_source, queryset=prefetch_queryset.model.objects.all(), request=request
+            )[0].query.where
+            if filter_node:  # check if any filtering is actually applied
+                if isinstance(prefetch, str):
+                    # Replace string prefetch with a filtered one
+                    prefetch = Prefetch(lookup=prefetch, queryset=filtered_queryset)
+                elif isinstance(prefetch, Prefetch):
+                    # add filters if not already applied
+                    if not contains_where_node(existing_node=prefetch_queryset.query.where, new_node=filter_node):
+                        prefetch.queryset = filtered_queryset
+                else:
+                    raise NotImplementedError(
+                        f"Adding filters to prefetch type {type(prefetch)} has not been implemented"
+                    )
+
+        return prefetch
+
+    def _add_prefetch(self, prefetches: Dict, prefetch: Union[str, Prefetch], request) -> str:
         # add prefetch to prefetches dict and return the prefetch_attr
-        # TODO: merge multi source prefetches if possible
-        # TODO: check Prefetch vs str type prefeches.
+        if not isinstance(prefetch, (str, Prefetch)):
+            raise ValueError(f"Adding prefetch of type '{type(prefetch)}' has not been implemented")
+        if isinstance(prefetch, str) and len(prefetch) == 1:
+            raise ValueError(f"single letter prefetches are not allowed")
 
-        if isinstance(prefetch, str):
-            prefetch_attr = prefetch
-        elif isinstance(prefetch, Prefetch):
-            prefetch_attr = prefetch.to_attr or prefetch.prefetch_through
-        else:
-            raise NotImplementedError(f"Adding '{type(prefetch)}' type object to prefetches has not been implemented")
+        prefetch = self._add_sideloading_filter(prefetch=prefetch, request=request)
 
+        prefetch_attr = self.get_source_from_prefetch(prefetch)
         existing_prefetch = prefetches.get(prefetch_attr)
-
         if not existing_prefetch:
             prefetches[prefetch_attr] = prefetch
         elif isinstance(existing_prefetch, str):
-            if prefetch != prefetches[prefetch_attr]:
-                raise ValueError("Two different prefetches for the same attribute")
+            # fixme: Check if different filters where applied to Prefetch queryset.
+            if isinstance(prefetch, str):
+                if prefetch != existing_prefetch:
+                    raise ValueError("Got different string prefetches to the same attribute name")
+            elif isinstance(prefetch, Prefetch):
+                if prefetch.queryset.query.where:
+                    raise ValueError(
+                        f"Can't add filtered Prefetch '{prefetch_attr}'. Existing prefetch does not have filters. "
+                        "APIView might have an unfiltered prefetch_related that sideloading is trying to filter."
+                    )
+                # Do nothing, as no filters where applied, leave the prefetch as a string
+            else:
+                raise NotImplementedError(f"overwriting existing string prefetch wit type {type(prefetch)}")
         elif isinstance(existing_prefetch, Prefetch):
-            # TODO: check for matching Prefetches not just a pointer match.
-            if prefetch.queryset != existing_prefetch.queryset:
-                raise ValueError("Prefetch with queryset overwriting existing prefetch")
-            # todo: find other clashing prefetch cases
+            if isinstance(prefetch, str):
+                if existing_prefetch.queryset.query.where:
+                    raise ValueError(
+                        f"Can't add non-filtered prefetch '{prefetch_attr}'. Existing Prefetch has filters applied. "
+                        "sideloading serializer tries to apply a non-filtered prefetch to a previously filtered prefetch"
+                    )
+                # Don't make any changes as the Prefetch does not have filters
+            elif isinstance(prefetch, Prefetch):
+                if prefetch.queryset.model != existing_prefetch.queryset.model:
+                    raise ValueError(
+                        f"Can't add filtered Prefetch '{prefetch_attr}'. Existing Prefetch has a different model."
+                    )
+                if set(prefetch.queryset.query.where.children) != set(existing_prefetch.queryset.query.where.children):
+                    raise ValueError(
+                        f"Can't add filtered Prefetch '{prefetch_attr}'. Existing Prefetch has different filters applied. "
+                        "Check that sideloading serializer and view prefetch_related values don't clash"
+                    )
+                # Don't make any changes as the filters have to match each other
+            else:
+                raise NotImplementedError(f"overwriting existing Prefetch with type {type(prefetch)}")
+        else:
+            raise NotImplementedError(f"Adding prefetch of type '{type(prefetch)}' has not been implemented")
 
         return prefetch_attr
 
-    def _get_relevant_prefetches(
-        self, sideloadable_fields: Dict, relations_to_sideload: Dict, cleaned_prefetches: Dict
-    ) -> Tuple[Dict, Dict]:
+    def _get_relevant_prefetches(self, relations_to_sideload: Dict, request, gathered_prefetches: Dict = None) -> Dict:
         """
         Collects all relevant prefetches and returns
         compressed prefetches and sources per relation to be used later.
         """
 
-        relations_sources = {}
-        gathered_prefetches = {}
+        if gathered_prefetches is None:
+            gathered_prefetches = {}
 
-        if not sideloadable_fields:
-            raise ValueError("'sideloadable_fields' is a required argument")
+        # cleaned prefetches
+        cleaned_prefetches = self._gather_all_prefetches()
+
         if not relations_to_sideload:
             raise ValueError("'relations_to_sideload' is a required argument")
         if not cleaned_prefetches:
@@ -571,129 +665,16 @@ class SideloadableRelationsMixin(object):
 
         for relation, requested_sources in relations_to_sideload.items():
             relation_prefetches = cleaned_prefetches.get(relation)
-            field_source = sideloadable_fields[relation].child.source
-            data_source = field_source
-
-            # gather prefetches and sources
-            if relation_prefetches is None:
-                raise ValueError(
-                    f"Missing prefetch for field '{relation}'. Check '_gather_all_prefetches' works correctly"
-                )
-            elif isinstance(relation_prefetches, list):
-                # No multi source used, load from source unless Prefetch object used
-                if requested_sources:
-                    raise ValueError(f"Got 'requested_sources' for field '{relation}' without MultiSource prefetches")
-
-                # find source
-                if data_source:
-                    pass
-                elif len(relation_prefetches) != 1:
-                    if any(pf == relation for pf in relation_prefetches):
-                        data_source = relation
-                    else:
-                        raise ValueError(
-                            "Unless source is defined or the field name matches the model, "
-                            "there can only be one prefetch, to define the relation"
-                        )
-                elif isinstance(relation_prefetches[0], str):
-                    data_source = relation_prefetches[0]
-                elif isinstance(relation_prefetches[0], Prefetch):
-                    data_source = relation_prefetches[0].to_attr or relation_prefetches[0].prefetch_through
-                else:
-                    raise ValueError(
-                        "Unless source is defined or the field name matches the model, "
-                        "There can only be one prefetch, to define the relation and it must be a string or Prefetch"
-                    )
-
-                if any(isinstance(prefetch, Prefetch) for prefetch in relation_prefetches):
-                    # load data from Prefetch.to_attr object used
-                    if len(relation_prefetches) != 1:
-                        raise ValueError(
-                            "If Prefetch is used, there can only one prefetch. "
-                            "Others must be defined within Prefetch.queryset"
-                        )
-                    # take values from Prefetch.to_attr
-                    prefetch_attr = self._add_prefetch(prefetches=gathered_prefetches, prefetch=relation_prefetches[0])
-                    relations_sources[relation] = data_source or prefetch_attr
-                else:
-                    # all prefetches are strings:
-
-                    # find source
-                    if not data_source:
-                        if getattr(self.get_serializer_class().Meta.model, relation, None):
-                            data_source = relation
-                        elif len(relation_prefetches) == 1:
-                            data_source = relation_prefetches[0]
-                        elif any(pf == relation for pf in relation_prefetches):
-                            data_source = relation
-                        else:
-                            raise ValueError(
-                                "Unless source is defined or the field name matches the model, "
-                                "there can only be one prefetch, to define the relation"
-                            )
-
-                    for prefetch in relation_prefetches:
-                        self._add_prefetch(prefetches=gathered_prefetches, prefetch=prefetch)
-                    relations_sources[relation] = data_source
-
-            # if not field_source
+            if requested_sources:
+                for source in requested_sources:
+                    for source_prefetch in relation_prefetches[source]:
+                        self._add_prefetch(prefetches=gathered_prefetches, prefetch=source_prefetch, request=request)
             elif isinstance(relation_prefetches, dict):
-                # its a MultiSource field, fetch values from sources defined with prefetches.
-                if field_source:
-                    raise ValueError("Multi source field with source defined in serializer.")
-
-                if requested_sources:
-                    for invalid_source_key in set(requested_sources) - set(relation_prefetches.keys()):
-                        msg = _(
-                            f"'{invalid_source_key}' is not one of the available source keys for relation '{relation}'"
-                        )
-                        raise ValidationError({self.sideloading_query_param_name: [msg]})
-
-                elif "__all__" in relation_prefetches:
-                    # find source in case it's not a Prefetch object.
-                    # requested_sources = [relation_prefetches["__all__"].to_attr]
-                    raise NotImplementedError("default prefetch for all in not implemented")
-                elif relation_prefetches:
-                    requested_sources = list(relation_prefetches.keys())
-                else:
-                    raise ValueError("Prefetches missing")
-
-                # collect field prefetches and sources
-                relations_sources[relation] = dict()
-                for source_key in requested_sources:
-                    if relations_sources[relation].get(source_key):
-                        raise ValueError(
-                            "Multiple sources defined for single multi source field. "
-                            "Prefetch or select related within Prefetch queryset."
-                        )
-                    source_prefetches = relation_prefetches[source_key]
-                    if not isinstance(source_prefetches, list):
-                        source_prefetches = [source_prefetches]
-
-                    if any(isinstance(prefetch, Prefetch) for prefetch in source_prefetches):
-                        # load data from Prefetch.to_attr object used
-                        if len(source_prefetches) != 1:
-                            raise ValueError(
-                                "If Prefetch is used, there can only one prefetch. "
-                                "Others must be defined within Prefetch.queryset"
-                            )
-
-                    # This adds all of the required prefetches to prefetches list
-                    source_prefetch_attrs = []
+                for source_prefetches in relation_prefetches.values():
                     for source_prefetch in source_prefetches:
-                        source_prefetch_attrs.append(
-                            self._add_prefetch(prefetches=gathered_prefetches, prefetch=source_prefetch)
-                        )
-
-                    # This adds the key to what resource needs to be loaded for each source
-                    # Note: sort the source perefetch attrs so that the actual source will be the first one.
-                    relations_sources[relation][source_key] = sorted(source_prefetch_attrs)[0]
+                        self._add_prefetch(prefetches=gathered_prefetches, prefetch=source_prefetch, request=request)
             else:
-                raise NotImplementedError(
-                    f"Sideloading with prefetch type {type(relation_prefetches)} has not been implemented"
-                )
+                for relation_prefetch in relation_prefetches:
+                    self._add_prefetch(prefetches=gathered_prefetches, prefetch=relation_prefetch, request=request)
 
-            if not relations_sources[relation]:
-                raise ValueError("Source not found")
-
-        return gathered_prefetches, relations_sources
+        return gathered_prefetches

--- a/drf_sideloading/schema.py
+++ b/drf_sideloading/schema.py
@@ -1,9 +1,7 @@
-from typing import Dict, List
+from typing import Dict, Union
 from django.utils.translation import gettext_lazy as _
 
 from drf_spectacular.utils import (
-    extend_schema,
-    OpenApiResponse,
     OpenApiParameter,
     OpenApiExample,
     OpenApiTypes,
@@ -18,7 +16,7 @@ class SideloadingAutoSchema(AutoSchema):
         if self.method == "GET":
             # return self.override_parameters
             self.view.initialize_serializer(request=getattr(self.view, "request", None))
-            sideloading_keys_sources: Dict[str, str | Dict[str, str]] = self.view.get_sideloading_field_sources()
+            sideloading_keys_sources: Dict[str, Union[str, Dict[str, str]]] = self.view.get_sideloading_field_sources()
             sideloading_keys = list(k for k, v in sideloading_keys_sources.items() if isinstance(v, str))
             multi_source_sideloading_items = {
                 k: list(v.keys()) for k, v in sideloading_keys_sources.items() if isinstance(v, dict)

--- a/drf_sideloading/schema.py
+++ b/drf_sideloading/schema.py
@@ -1,0 +1,57 @@
+from typing import Dict, List
+from django.utils.translation import gettext_lazy as _
+
+from drf_spectacular.utils import (
+    extend_schema,
+    OpenApiResponse,
+    OpenApiParameter,
+    OpenApiExample,
+    OpenApiTypes,
+)
+from drf_spectacular.openapi import AutoSchema
+
+
+class SideloadingAutoSchema(AutoSchema):
+    override_parameters = []
+
+    def get_override_parameters(self):
+        if self.method == "GET":
+            # return self.override_parameters
+            sideloading_keys_sources: Dict[str, List[str]] = self.view.get_sideloading_keys_sources()
+            sideloading_keys = list(k for k, v in sideloading_keys_sources.items() if not v)
+            multi_source_sideloading_items = {k: v for k, v in sideloading_keys_sources.items() if v}
+            examples = []
+            if sideloading_keys:
+                examples.append(
+                    OpenApiExample(
+                        name=_("Regular sideloading"),
+                        value=",".join(sideloading_keys[:2]),
+                        request_only=True,
+                    )
+                )
+            for k, v in multi_source_sideloading_items.items():
+                examples.append(
+                    OpenApiExample(
+                        name=_(f"Multi source sideloading for {k}"),
+                        value=f"{k}[{','.join(v)}]",
+                        request_only=True,
+                    )
+                )
+            return [
+                OpenApiParameter(
+                    name="sideload",
+                    type=OpenApiTypes.STR,
+                    location=OpenApiParameter.QUERY,
+                    many=True,
+                    description=_(
+                        "This option allows you to fetch related obejcts for all of the relations with a signle query. "
+                        "Multi-source sideloadable fields can be filtered by the sources by declaring the required "
+                        "sources in square brackets after the sideloading key. All available Mutli-source fields will "
+                        "have an example provided with all available sources. The comma separated sources can be "
+                        "ommited with the square brackets if all sources are to be sideloaded."
+                    ),
+                    enum=sideloading_keys_sources.keys(),
+                    examples=examples,
+                )
+            ]
+        return []

--- a/drf_sideloading/schema.py
+++ b/drf_sideloading/schema.py
@@ -17,9 +17,12 @@ class SideloadingAutoSchema(AutoSchema):
     def get_override_parameters(self):
         if self.method == "GET":
             # return self.override_parameters
-            sideloading_keys_sources: Dict[str, List[str]] = self.view.get_sideloading_keys_sources()
-            sideloading_keys = list(k for k, v in sideloading_keys_sources.items() if not v)
-            multi_source_sideloading_items = {k: v for k, v in sideloading_keys_sources.items() if v}
+            self.view.initialize_serializer(request=getattr(self.view, "request", None))
+            sideloading_keys_sources: Dict[str, str | Dict[str, str]] = self.view.get_sideloading_field_sources()
+            sideloading_keys = list(k for k, v in sideloading_keys_sources.items() if isinstance(v, str))
+            multi_source_sideloading_items = {
+                k: list(v.keys()) for k, v in sideloading_keys_sources.items() if isinstance(v, dict)
+            }
             examples = []
             if sideloading_keys:
                 examples.append(

--- a/example/urls.py
+++ b/example/urls.py
@@ -13,8 +13,9 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
+
 from django.conf import settings
-from django.conf.urls import url, include
+from django.urls import path, include
 from django.contrib import admin
 from rest_framework import routers
 
@@ -32,10 +33,10 @@ router.register(r"suppliers", SupplierViewSet)
 router.register(r"partners", PartnerViewSet)
 
 
-urlpatterns = [url(r"^admin/", admin.site.urls), url(r"^", include(router.urls))]
+urlpatterns = [path("admin/", admin.site.urls), path("", include(router.urls))]
 
 
 if settings.DEBUG:
     import debug_toolbar
 
-    urlpatterns = [url(r"^__debug__/", include(debug_toolbar.urls))] + urlpatterns
+    urlpatterns = [path("__debug__/", include(debug_toolbar.urls))] + urlpatterns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 120
-target-version = ["py37", "py38"]
+target-version = ["py37", "py38", "py39", "py310", "py311"]
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 120
-target-version = ["py37", "py38", "py39", "py310", "py311"]
+target-version = ["py37", "py38", "py39", "py310", "py311", "py312"]
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,5 +7,5 @@ twine
 wheel
 recommonmark
 
-django>=2.2,<4.0
+django>=2.2,<5.0
 djangorestframework>=3.9,<4.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -8,9 +8,8 @@ sphinx
 recommonmark
 
 # supported django and DRF
-django>=2.2,<4.0
+django>=2.2,<5.0
 djangorestframework>=3.9,<4.0
-djangorestframework==3.12.4
 
 # to test conflicts with filtering
 django-filter

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,5 @@
+setuptools
+
 coverage==4.3.4
 mock>=1.0.1
 flake8>=2.1.0
@@ -8,7 +10,7 @@ sphinx
 recommonmark
 
 # supported django and DRF
-django>=2.2,<5.0
+django>=2.2,<5.2
 djangorestframework>=3.9,<4.0
 
 # to test conflicts with filtering

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,5 +17,5 @@ exclude =
 	docs/conf.py,
 	build,
 	dist
-max-line-length = 119
+max-line-length = 120
 

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,9 @@ setup(
         "Framework :: Django :: 3.0",
         "Framework :: Django :: 3.1",
         "Framework :: Django :: 3.2",
+        "Framework :: Django :: 4.0",
+        "Framework :: Django :: 4.1",
+        "Framework :: Django :: 4.2",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
@@ -74,5 +77,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -79,5 +79,6 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
 )

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -58,7 +58,8 @@ class ProductSideloadableSerializer(SideLoadableSerializer):
             "main_suppliers": "supplier",
             "backup_suppliers": "backup_supplier",
             "partners": "partners",
-            # These can be defined to always load them, else they will be copied over form all sources or selected sources only.
+            # These can be defined to always load them, else they will be
+            # copied over form all sources or selected sources only.
             "combined_suppliers": {
                 "suppliers": ["supplier"],
                 "backup_supplier": ["backup_supplier"],
@@ -81,7 +82,8 @@ class NewProductSideloadableSerializer(SideLoadableSerializer):
             "new_main_suppliers": "supplier",
             "new_backup_suppliers": "backup_supplier",
             "new_partners": "partners",
-            # These can be defined to always load them, else they will be copied over form all sources or selected sources only.
+            # These can be defined to always load them, else they will be
+            # copied over form all sources or selected sources only.
             "combined_suppliers": {
                 "suppliers": ["supplier"],
                 "backup_supplier": ["backup_supplier"],

--- a/tests/test_products_api.py
+++ b/tests/test_products_api.py
@@ -191,7 +191,8 @@ class ProductMultiSourceSideloadTestCase(BaseTestCase):
                     "main_suppliers": "supplier",
                     "backup_suppliers": "backup_supplier",
                     "partners": "partners",
-                    # These can be defined to always load them, else they will be copied over form all sources or selected sources only.
+                    # These can be defined to always load them, else they will be
+                    # copied over form all sources or selected sources only.
                     "combined_suppliers": {
                         "suppliers": {"lookup": "supplier"},
                         "backup_suppliers": {"lookup": "backup_supplier"},
@@ -829,7 +830,7 @@ class TestDrfSideloadingPrefetchObjectsMatchingLookup(BaseTestCase):
             list(response_1.json().keys()),
         )
         # check filtered_suppliers and filtered_partners are different from suppliers and partners!
-        partner_names = {partner["name"] for partner in response_1.json()["partners"]}
+        # partner_names = {partner["name"] for partner in response_1.json()["partners"]}
         # FIXME: the Prefetch does not filter the queryset as expected!
         # self.assertSetEqual({"Partner2", "Partner4"}, partner_names)
 

--- a/tests/test_products_api.py
+++ b/tests/test_products_api.py
@@ -162,7 +162,7 @@ class ProductSideloadTestCase(BaseTestCase):
     def test_sideloading_param_wrongly_formed_query(self):
         response = self.client.get(
             path=reverse("product-list"),
-            data={"sideload": ",,@,123,categories,123,.unexisting,123,,,,suppliers,!@"},
+            data={"sideload": "@,123,categories,123,.unexisting,123,,,,suppliers,!@"},
             **self.DEFAULT_HEADERS,
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/tests/test_products_api.py
+++ b/tests/test_products_api.py
@@ -579,96 +579,91 @@ class TestDrfSideloadingValidPrefetches(BaseTestCase):
         partner_names = {partner["name"] for partner in response_2.json()["partners"]}
         self.assertSetEqual({"Partner1", "Partner2", "Partner3", "Partner4"}, partner_names)
 
-    # # fixme: for some reason, the filtered_suppliers is not sideloaded altho Prefetch present in queryset arguments
-    # #  because queryset is called as a generator maybe? In that case, the prefetches do nothing
-    # def test_sideloading_normally(self):
-    #     response_1 = self.client.get(
-    #         path=reverse("product-list"),
-    #         data={"sideload": "categories,suppliers,filtered_suppliers,partners,filtered_partners"},
-    #         **self.DEFAULT_HEADERS,
-    #     )
-    #     self.assertEqual(response_1.status_code, status.HTTP_200_OK, response.json())
-    #     self.assertIsInstance(response_1.json(), dict)
-    #     self.assertListEqual(
-    #         ["products", "categories", "suppliers", "filtered_suppliers", "partners", "filtered_partners"],
-    #         list(response_1.json().keys()),
-    #     )
-    #     # check filtered_suppliers and filtered_partners are different from suppliers and partners!
-    #     supplier_names = {partner["name"] for partner in response_1.json()["suppliers"]}
-    #     self.assertSetEqual({"Supplier1", "Supplier2", "Supplier3", "Supplier4"}, supplier_names)
-    #
-    #     filtered_supplier_names = {partner["name"] for partner in response_1.json()["filtered_suppliers"]}
-    #     self.assertSetEqual({"Supplier2", "Supplier4"}, filtered_supplier_names)
-    #
-    #     partner_names = {partner["name"] for partner in response_1.json()["partners"]}
-    #     self.assertSetEqual({"Partner1", "Partner2", "Partner3", "Partner4"}, partner_names)
-    #
-    #     filtered_partner_names = {partner["name"] for partner in response_1.json()["filtered_partners"]}
-    #     self.assertSetEqual({"Partner2", "Partner4"}, filtered_partner_names)
-    #
-    # # fixme: for some reason, the filtered_suppliers is not sideloaded altho Prefetch present in queryset arguments
-    # def test_sideloading_with_filtered_prefetch(self):
-    #     response_1 = self.client.get(
-    #         path=reverse("product-list"),
-    #         data={"sideload": "filtered_suppliers,filtered_partners"},
-    #         **self.DEFAULT_HEADERS,
-    #     )
-    #     self.assertEqual(response_1.status_code, status.HTTP_200_OK, response.json())
-    #     self.assertIsInstance(response_1.json(), dict)
-    #     self.assertListEqual(
-    #         ["products", "filtered_suppliers", "filtered_partners"],
-    #         list(response_1.json().keys()),
-    #     )
-    #     filtered_supplier_names = {partner["name"] for partner in response_1.json()["filtered_suppliers"]}
-    #     self.assertSetEqual({"Supplier2", "Supplier4"}, filtered_supplier_names)
-    #
-    #     filtered_partner_names = {partner["name"] for partner in response_1.json()["filtered_partners"]}
-    #     self.assertSetEqual({"Partner2", "Partner4"}, filtered_partner_names)
-    #
-    # # fixme: for some reason, the filtered_suppliers is not sideloaded altho Prefetch present in queryset arguments
-    # def test_sideloading_with_filtered_prefetches(self):
-    #     response_1 = self.client.get(
-    #         path=reverse("product-list"),
-    #         data={"sideload": "categories,filtered_suppliers,filtered_suppliers2,filtered_partners"},
-    #         **self.DEFAULT_HEADERS,
-    #     )
-    #     self.assertEqual(response_1.status_code, status.HTTP_200_OK, response.json())
-    #     self.assertIsInstance(response_1.json(), dict)
-    #     self.assertListEqual(
-    #         ["products", "categories", "filtered_suppliers", "filtered_suppliers2", "filtered_partners"],
-    #         list(response_1.json().keys()),
-    #     )
-    #     # check filtered_suppliers and filtered_partners are different from suppliers and partners!
-    #
-    #     filtered_supplier_names = {supplier["name"] for supplier in response_1.json()["filtered_suppliers"]}
-    #     self.assertSetEqual({"Supplier2", "Supplier4"}, filtered_supplier_names)
-    #
-    #     filtered_supplier_names = {supplier["name"] for supplier in response_1.json()["filtered_suppliers2"]}
-    #     self.assertSetEqual({"Supplier3"}, filtered_supplier_names)
-    #
-    #     filtered_partner_names = {partner["name"] for partner in response_1.json()["filtered_partners"]}
-    #     self.assertSetEqual({"Partner2", "Partner4"}, filtered_partner_names)
-    #
-    # # fixme: for some reason, the filtered_suppliers is not sideloaded altho Prefetch present in queryset arguments
-    # def test_sideloading_combined_suppliers_with_filtered_prefetches(self):
-    #     response_1 = self.client.get(
-    #         path=reverse("product-list"),
-    #         data={"sideload": "categories,filtered_suppliers,filtered_partners"},
-    #         **self.DEFAULT_HEADERS,
-    #     )
-    #     self.assertEqual(response_1.status_code, status.HTTP_200_OK, response.json())
-    #     self.assertIsInstance(response_1.json(), dict)
-    #     self.assertListEqual(
-    #         ["products", "categories", "filtered_suppliers", "filtered_partners"],
-    #         list(response_1.json().keys()),
-    #     )
-    #     # check filtered_suppliers and filtered_partners are different from suppliers and partners!
-    #
-    #     filtered_supplier_names = {partner["name"] for partner in response_1.json()["filtered_suppliers"]}
-    #     self.assertSetEqual({"Supplier2", "Supplier4"}, filtered_supplier_names)
-    #
-    #     filtered_partner_names = {partner["name"] for partner in response_1.json()["filtered_partners"]}
-    #     self.assertSetEqual({"Partner2", "Partner4"}, filtered_partner_names)
+    def test_sideloading_normally(self):
+        response_1 = self.client.get(
+            path=reverse("product-list"),
+            data={"sideload": "categories,suppliers,filtered_suppliers,partners,filtered_partners"},
+            **self.DEFAULT_HEADERS,
+        )
+        self.assertEqual(response_1.status_code, status.HTTP_200_OK, response_1.json())
+        self.assertIsInstance(response_1.json(), dict)
+        self.assertListEqual(
+            ["products", "categories", "suppliers", "filtered_suppliers", "partners", "filtered_partners"],
+            list(response_1.json().keys()),
+        )
+        # check filtered_suppliers and filtered_partners are different from suppliers and partners!
+        supplier_names = {partner["name"] for partner in response_1.json()["suppliers"]}
+        self.assertSetEqual({"Supplier1", "Supplier2", "Supplier3", "Supplier4"}, supplier_names)
+
+        filtered_supplier_names = {partner["name"] for partner in response_1.json()["filtered_suppliers"]}
+        self.assertSetEqual({"Supplier2", "Supplier4"}, filtered_supplier_names)
+
+        partner_names = {partner["name"] for partner in response_1.json()["partners"]}
+        self.assertSetEqual({"Partner1", "Partner2", "Partner3", "Partner4"}, partner_names)
+
+        filtered_partner_names = {partner["name"] for partner in response_1.json()["filtered_partners"]}
+        self.assertSetEqual({"Partner2", "Partner4"}, filtered_partner_names)
+
+    def test_sideloading_with_filtered_prefetch(self):
+        response_1 = self.client.get(
+            path=reverse("product-list"),
+            data={"sideload": "filtered_suppliers,filtered_partners"},
+            **self.DEFAULT_HEADERS,
+        )
+        self.assertEqual(response_1.status_code, status.HTTP_200_OK, response_1.json())
+        self.assertIsInstance(response_1.json(), dict)
+        self.assertListEqual(
+            ["products", "filtered_suppliers", "filtered_partners"],
+            list(response_1.json().keys()),
+        )
+        filtered_supplier_names = {partner["name"] for partner in response_1.json()["filtered_suppliers"]}
+        self.assertSetEqual({"Supplier2", "Supplier4"}, filtered_supplier_names)
+
+        filtered_partner_names = {partner["name"] for partner in response_1.json()["filtered_partners"]}
+        self.assertSetEqual({"Partner2", "Partner4"}, filtered_partner_names)
+
+    def test_sideloading_with_filtered_prefetches(self):
+        response_1 = self.client.get(
+            path=reverse("product-list"),
+            data={"sideload": "categories,filtered_suppliers,filtered_suppliers2,filtered_partners"},
+            **self.DEFAULT_HEADERS,
+        )
+        self.assertEqual(response_1.status_code, status.HTTP_200_OK, response_1.json())
+        self.assertIsInstance(response_1.json(), dict)
+        self.assertListEqual(
+            ["products", "categories", "filtered_suppliers", "filtered_suppliers2", "filtered_partners"],
+            list(response_1.json().keys()),
+        )
+        # check filtered_suppliers and filtered_partners are different from suppliers and partners!
+
+        filtered_supplier_names = {supplier["name"] for supplier in response_1.json()["filtered_suppliers"]}
+        self.assertSetEqual({"Supplier2", "Supplier4"}, filtered_supplier_names)
+
+        filtered_supplier_names = {supplier["name"] for supplier in response_1.json()["filtered_suppliers2"]}
+        self.assertSetEqual({"Supplier3"}, filtered_supplier_names)
+
+        filtered_partner_names = {partner["name"] for partner in response_1.json()["filtered_partners"]}
+        self.assertSetEqual({"Partner2", "Partner4"}, filtered_partner_names)
+
+    def test_sideloading_combined_suppliers_with_filtered_prefetches(self):
+        response_1 = self.client.get(
+            path=reverse("product-list"),
+            data={"sideload": "categories,filtered_suppliers,filtered_partners"},
+            **self.DEFAULT_HEADERS,
+        )
+        self.assertEqual(response_1.status_code, status.HTTP_200_OK, response_1.json())
+        self.assertIsInstance(response_1.json(), dict)
+        self.assertListEqual(
+            ["products", "categories", "filtered_suppliers", "filtered_partners"],
+            list(response_1.json().keys()),
+        )
+        # check filtered_suppliers and filtered_partners are different from suppliers and partners!
+
+        filtered_supplier_names = {partner["name"] for partner in response_1.json()["filtered_suppliers"]}
+        self.assertSetEqual({"Supplier2", "Supplier4"}, filtered_supplier_names)
+
+        filtered_partner_names = {partner["name"] for partner in response_1.json()["filtered_partners"]}
+        self.assertSetEqual({"Partner2", "Partner4"}, filtered_partner_names)
 
 
 class TestDrfSideloadingInvalidPrefetchSource(BaseTestCase):
@@ -777,15 +772,17 @@ class TestDrfSideloadingValidPrefetchObjectsImplicit(BaseTestCase):
 
         ProductViewSet.sideloading_serializer_class = TempProductSideloadableSerializer
 
-    # TODO: fix test as we get an error: "Two different prefetches for the same attribute"
-    # def test_sideloading_with_prefetch_object_without_to_attr(self):
-    #     msg = f"Either source or prefetches must be set for sideloadable field 'partners'"
-    #     with self.assertRaisesMessage(ValueError, msg):
-    #         self.client.get(
-    #             path=reverse("product-list"),
-    #             data={"sideload": "categories,suppliers,filtered_suppliers,partners"},
-    #             **self.DEFAULT_HEADERS,
-    #         )
+    def test_sideloading_with_prefetch_object_without_to_attr(self):
+        msg = (
+            "Can't add filtered Prefetch 'supplier'. Existing prefetch does not have filters. "
+            "APIView might have an unfiltered prefetch_related that sideloading is trying to filter."
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            self.client.get(
+                path=reverse("product-list"),
+                data={"sideload": "categories,suppliers,filtered_suppliers,partners"},
+                **self.DEFAULT_HEADERS,
+            )
 
 
 class TestDrfSideloadingPrefetchObjectsMatchingLookup(BaseTestCase):
@@ -830,9 +827,8 @@ class TestDrfSideloadingPrefetchObjectsMatchingLookup(BaseTestCase):
             list(response_1.json().keys()),
         )
         # check filtered_suppliers and filtered_partners are different from suppliers and partners!
-        # partner_names = {partner["name"] for partner in response_1.json()["partners"]}
-        # FIXME: the Prefetch does not filter the queryset as expected!
-        # self.assertSetEqual({"Partner2", "Partner4"}, partner_names)
+        partner_names = {partner["name"] for partner in response_1.json()["partners"]}
+        self.assertSetEqual({"Partner2", "Partner4"}, partner_names)
 
 
 class TestDrfSideloadingInvalidPrefetchObject(BaseTestCase):
@@ -873,15 +869,18 @@ class TestDrfSideloadingInvalidPrefetchObject(BaseTestCase):
 
         ProductViewSet.sideloading_serializer_class = TempProductSideloadableSerializer
 
-    # # TODO: fix this for cases where field source is present but Prefetch.to_attr mismatches
-    # def test_sideloading_with_prefetches(self):
-    #     msg = f"Either source or prefetches must be set for sideloadable field 'partners'"
-    #     with self.assertRaisesMessage(ValueError, msg):
-    #         self.client.get(
-    #             path=reverse("product-list"),
-    #             data={"sideload": "categories,suppliers,filtered_suppliers,partners"},
-    #             **self.DEFAULT_HEADERS,
-    #         )
+    def test_sideloading_with_prefetches(self):
+        # cases where field source is present but Prefetch.to_attr mismatches
+        msg = (
+            "Sideloadable field 'filtered_suppliers' Prefetch 'to_attr' can't be different from source defined. "
+            "Tip: Remove source from field serializer."
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            self.client.get(
+                path=reverse("product-list"),
+                data={"sideload": "categories,suppliers,filtered_suppliers,partners"},
+                **self.DEFAULT_HEADERS,
+            )
 
 
 class TestDrfSideloadingWithoutListModelMixin(BaseTestCase):

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url, include
+from django.urls import path, include
 from rest_framework import routers
 
 from tests import viewsets
@@ -14,4 +14,4 @@ router.register(r"category", viewsets.CategoryViewSet)
 router.register(r"supplier", viewsets.SupplierViewSet)
 router.register(r"partner", viewsets.PartnerViewSet)
 
-urlpatterns = [url(r"^", include(router.urls))]
+urlpatterns = [path("", include(router.urls))]

--- a/tests/viewsets.py
+++ b/tests/viewsets.py
@@ -1,11 +1,5 @@
 from rest_framework import viewsets, filters, versioning
-from rest_framework.mixins import (
-    CreateModelMixin,
-    RetrieveModelMixin,
-    UpdateModelMixin,
-    DestroyModelMixin,
-    ListModelMixin,
-)
+from rest_framework.mixins import RetrieveModelMixin, ListModelMixin
 from rest_framework.viewsets import GenericViewSet
 
 from drf_sideloading.mixins import SideloadableRelationsMixin

--- a/tests/viewsets.py
+++ b/tests/viewsets.py
@@ -37,11 +37,11 @@ class ProductViewSet(SideloadableRelationsMixin, OtherMixin, viewsets.ModelViewS
         # if no super is called sideloading should still work
         return self.serializer_class
 
-    def get_sideloading_serializer_class(self):
+    def get_sideloading_serializer_class(self, request=None):
         # if no super is called sideloading should still work
         if self.request.version == "2.0.0":
             return NewProductSideloadableSerializer
-        return self.sideloading_serializer_class
+        return super().get_sideloading_serializer_class(request=request)
 
 
 class ListOnlyProductViewSet(SideloadableRelationsMixin, OtherMixin, ListModelMixin, GenericViewSet):

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,32 @@
 [tox]
 envlist =
-       {py36}-django22-drf{39,310,311,312},
-       {py37}-django22-drf{39,310,311,312},
-       {py38}-django22-drf{39,310,311,312},
-       {py39}-django22-drf{39,310,311,312},
+       py36-django22-drf{39,310,311,312},
+       py37-django22-drf{39,310,311,312},
+       py38-django22-drf{39,310,311,312},
+       py39-django22-drf{39,310,311,312},
 
-       {py36}-django{31,32}-drf{312},
-       {py37}-django{31,32}-drf{312},
-       {py38}-django{31,32}-drf{312},
-       {py39}-django{31,32}-drf{312},
+       py36-django{31,32}-drf312,
+       py37-django{31,32}-drf312,
+       py38-django{31,32}-drf312,
+       py39-django{31,32}-drf312,
+       py310-django32-drf312,
+
+       py38-django40-drf{313,314},
+       py39-django40-drf{313,314},
+       py310-django40-drf{313,314},
+
+       py38-django41-drf314,
+       py39-django41-drf314,
+       py310-django41-drf314,
+       py311-django{41,42}-drf314,
+
        lint
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/drf_sideloading
     PYTHONDONTWRITEBYTECODE=1
+allowlist_externals = coverage
 commands =
     coverage run --source drf_sideloading runtests.py
 
@@ -22,24 +34,32 @@ deps =
     django22: Django>=2.2,<2.3
     django31: Django>=3.1,<3.2
     django32: Django>=3.2,<3.3
+    django40: Django>=4.0,<4.1
+    django41: Django>=4.1,<4.2
+    django42: Django>=4.2,<4.3
     drf39: djangorestframework>=3.9,<3.10
     drf310: djangorestframework>=3.10,<3.11
     drf311: djangorestframework>=3.11,<3.12
     drf312: djangorestframework>=3.12,<3.13
+    drf313: djangorestframework>=3.13,<3.14
+    drf314: djangorestframework>=3.14,<3.15
     -r{toxinidir}/requirements_test.txt
 basepython =
+    py311: python3.11
+    py310: python3.10
     py39: python3.9
     py38: python3.8
     py37: python3.7
     py36: python3.6
 
 passenv=
-    PYTHONPATH = {toxinidir}:{toxinidir}
+    PYTHONPATH: {toxinidir}:{toxinidir}
 
 
 [testenv:lint]
-basepython = python3.8
+basepython =
+    python3.11
 deps =
     flake8
-whitelist_externals = make
+allowlist_externals = make
 commands = make lint

--- a/tox.ini
+++ b/tox.ini
@@ -1,26 +1,37 @@
 [tox]
 envlist =
-       py36-django22-drf{39,310,311,312},
-       py37-django22-drf{39,310,311,312},
-       py38-django22-drf{39,310,311,312},
-       py39-django22-drf{39,310,311,312},
+    # django 2
+    py36-django22-drf{39,310,311,312},
+    py37-django22-drf{39,310,311,312},
+    py38-django22-drf{39,310,311,312},
+    py39-django22-drf{39,310,311,312},
 
-       py36-django{31,32}-drf312,
-       py37-django{31,32}-drf312,
-       py38-django{31,32}-drf312,
-       py39-django{31,32}-drf312,
-       py310-django32-drf312,
+    # django 3
+    py36-django{31,32}-drf312,
+    py37-django{31,32}-drf312,
+    py38-django{31,32}-drf312,
+    py39-django{31,32}-drf312,
+    py310-django32-drf312,
 
-       py38-django40-drf{313,314},
-       py39-django40-drf{313,314},
-       py310-django40-drf{313,314},
+    # django 4.0
+    py38-django40-drf{313,314},
+    py39-django40-drf{313,314},
+    py310-django40-drf{313,314},
 
-       py38-django41-drf314,
-       py39-django41-drf314,
-       py310-django41-drf314,
-       py311-django{41,42}-drf314,
+    # django 4.1+
+    py38-django41-drf314,
+    py39-django41-drf314,
+    py310-django41-drf314,
+    py311-django{41,42}-drf314,
 
-       lint
+    # Django 5.0
+    #  * Python < 3.10 no longer supported
+    #  * DRF 3.15 first to support django 5
+    py310-django{50,51}-drf315,
+    py311-django{50,51}-drf315,
+    py312-django{50,51}-drf315,
+
+    lint
 
 [testenv]
 setenv =
@@ -31,34 +42,41 @@ commands =
     coverage run --source drf_sideloading runtests.py
 
 deps =
+    # Django
     django22: Django>=2.2,<2.3
     django31: Django>=3.1,<3.2
     django32: Django>=3.2,<3.3
     django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
+    django50: Django>=5.0,<5.1
+    django51: Django>=5.1,<5.2
+    # Django rest framework
     drf39: djangorestframework>=3.9,<3.10
     drf310: djangorestframework>=3.10,<3.11
     drf311: djangorestframework>=3.11,<3.12
     drf312: djangorestframework>=3.12,<3.13
     drf313: djangorestframework>=3.13,<3.14
     drf314: djangorestframework>=3.14,<3.15
+    drf315: djangorestframework>=3.15,<3.16
+
     -r{toxinidir}/requirements_test.txt
+
 basepython =
-    py311: python3.11
-    py310: python3.10
-    py39: python3.9
-    py38: python3.8
-    py37: python3.7
     py36: python3.6
+    py37: python3.7
+    py38: python3.8
+    py39: python3.9
+    py310: python3.10
+    py311: python3.11
+    py312: python3.12
 
-passenv=
-    PYTHONPATH: {toxinidir}:{toxinidir}
-
+passenv =
+    PYTHONPATH
 
 [testenv:lint]
 basepython =
-    python3.11
+    python3.12
 deps =
     flake8
 allowlist_externals = make


### PR DESCRIPTION
Add support for Django 4 and 5

Support for Django 5
  - Django supported versions 5.0 -> 5.1
  - Python supported versions 3.10 -> 3.12
  - Django-rest-framework supported versions. 3.15
  
Support for Django 4
  - Django supported versions 4.0 -> 4.2
  - Python supported versions 3.8 -> 3.11
  - Django-rest-framework supported versions. 3.13 -> 3.14

from merged branches: 
* Documentation generation
  * Generate documentation for sideloading parameter
* prefetch filtering 
  * refactor for readability
  * honor prefetches added to the View
  * allow the user to write code to apply extra request based filters
  * only raise method_not_allowed error when the method is actually missing